### PR TITLE
 Rename download_mac flag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,15 +35,14 @@ Install from PyPi
     pip install py-ard
 
 Testing
-
 -------
-To run behavior-driven development (BDD) tests locally via the behave framework, 
-you'll need to set up a virtual environment.
+
+To run behavior-driven development (BDD) tests locally via the behave framework,
+you'll need to set up a virtual environment. See Install from source
 
 .. code-block::
-    # Virtual environment setup
-    python3 -m venv testing
-    source testing/bin/activate
+
+    # Install test dependencies
     pip install --upgrade pip
     pip install -r test-requirements.txt
 
@@ -61,7 +60,7 @@ Example
     ard = ARD('3290')
 
     # You can specify a data directory for temp files
-    # ard = ard = ARD('3290', data_dir='/tmp/py-ard')
+    # ard = ARD('3290', data_dir='/tmp/py-ard')
 
     # Initialize with latest DB
     ard = ARD()

--- a/pyard/__init__.py
+++ b/pyard/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 #
-#    pyars pyARS.
+#    pyard pyARD.
 #    Copyright (c) 2018 Be The Match operated by National Marrow Donor Program. All Rights Reserved.
 #
 #    This library is free software; you can redistribute it and/or modify it
@@ -21,7 +21,6 @@
 #    > http://www.fsf.org/licensing/licenses/lgpl.html
 #    > http://www.opensource.org/licenses/lgpl-license.php
 #
-from __future__ import absolute_import
 from .pyard import ARD
 
 __author__ = """NMDP Bioinformatics"""

--- a/pyard/__init__.py
+++ b/pyard/__init__.py
@@ -24,4 +24,4 @@
 from .pyard import ARD
 
 __author__ = """NMDP Bioinformatics"""
-__version__ = '0.0.22'
+__version__ = '0.1.0'

--- a/pyard/smart_sort.py
+++ b/pyard/smart_sort.py
@@ -1,3 +1,26 @@
+# -*- coding: utf-8 -*-
+
+#
+#    py-ard
+#    Copyright (c) 2020 Be The Match operated by National Marrow Donor Program. All Rights Reserved.
+#
+#    This library is free software; you can redistribute it and/or modify it
+#    under the terms of the GNU Lesser General Public License as published
+#    by the Free Software Foundation; either version 3 of the License, or (at
+#    your option) any later version.
+#
+#    This library is distributed in the hope that it will be useful, but WITHOUT
+#    ANY WARRANTY; with out even the implied warranty of MERCHANTABILITY or
+#    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+#    License for more details.
+#
+#    You should have received a copy of the GNU Lesser General Public License
+#    along with this library;  if not, write to the Free Software Foundation,
+#    Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA.
+#
+#    > http://www.fsf.org/licensing/licenses/lgpl.html
+#    > http://www.opensource.org/licenses/lgpl-license.php
+#
 import functools
 import re
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.22
+current_version = 0.1.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 requirements = [
-    'pandas==0.25.1'
+    'pandas==1.1.2'
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ test_requirements = [
 
 setup(
     name='py-ard',
-    version='0.0.22',
+    version='0.1.0',
     description="ARD reduction for HLA with python",
     long_description=readme + '\n\n' + history,
     author="CIBMTR",

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,2 @@
 behave==1.2.6
-pandas==0.25.1
 PyHamcrest==2.0.2

--- a/tests/environment.py
+++ b/tests/environment.py
@@ -1,4 +1,5 @@
 from pyard import ARD
 
+
 def before_all(context):
     context.ard = ARD(verbose=True)

--- a/tests/test_pyard.py
+++ b/tests/test_pyard.py
@@ -46,7 +46,7 @@ class TestPyArd(unittest.TestCase):
         self.assertIsInstance(self.ard, ARD)
 
     def test_no_mac(self):
-        self.ard_no_mac = ARD(self.db_version, data_dir='/tmp/3290', download_mac=False)
+        self.ard_no_mac = ARD(self.db_version, data_dir='/tmp/3290', load_mac_file=False)
         self.assertIsInstance(self.ard_no_mac, ARD)
         self.assertEqual(len(self.ard_no_mac.mac.keys()), 0)
         self.assertEqual(self.ard_no_mac.redux("A*01:01:01", 'G'), "A*01:01:01G")


### PR DESCRIPTION
 Rename download_mac flag

  - Rename `download_mac` ARD flag to `load_mac_file` as it properly describes what it does.
  - Remove dead code
  - Reformat code and fix some comments
  - Version bumped to `0.1.0`
  - Updated `pandas` to `1.1.2`