### PR TITLE
Refactor reference data to db

### DIFF
--- a/pyard/__init__.py
+++ b/pyard/__init__.py
@@ -24,4 +24,4 @@
 from .pyard import ARD
 
 __author__ = """NMDP Bioinformatics"""
-__version__ = '0.2.0'
+__version__ = '0.3.0'

--- a/pyard/data_repository.py
+++ b/pyard/data_repository.py
@@ -1,0 +1,233 @@
+import sqlite3
+
+import pandas as pd
+
+from pyard import db
+from pyard.broad_splits import broad_splits_mapping
+
+# GitHub URL where IMGT HLA files are downloaded.
+IMGT_HLA_URL = 'https://raw.githubusercontent.com/ANHIG/IMGTHLA/'
+
+# List of expression characters
+expression_chars = ['N', 'Q', 'L', 'S']
+
+
+def get_n_field_allele(allele: str, n: int) -> str:
+    """
+    Given an HLA allele of >= n field, return n field allele.
+    Preserve the expression character if it exists
+
+    :param allele: Original allele
+    :param n: n number of fields to reduce to
+    :return: trimmed to n fields of the original allele
+    """
+    last_char = allele[-1]
+    fields = allele.split(':')
+    if last_char in expression_chars and len(fields) > n:
+        return ':'.join(fields[0:n]) + last_char
+    else:
+        return ':'.join(fields[0:n])
+
+
+def get_3field_allele(a: str) -> str:
+    return get_n_field_allele(a, 3)
+
+
+def get_2field_allele(a: str) -> str:
+    return get_n_field_allele(a, 2)
+
+
+def generate_ars_mapping(db_connection: sqlite3.Connection, imgt_version):
+    if db.tables_exists(db_connection, ['dup_g', 'g_group', 'lg_group', 'lgx_group']):
+        dup_g = db.load_dict(db_connection, table_name='dup_g', columns=('allele', 'g_group'))
+        g_group = db.load_dict(db_connection, table_name='g_group', columns=('allele', 'g'))
+        lg_group = db.load_dict(db_connection, table_name='lg_group', columns=('allele', 'lg'))
+        lgx_group = db.load_dict(db_connection, table_name='lgx_group', columns=('allele', 'lgx'))
+        return dup_g, g_group, lg_group, lgx_group
+
+    ars_url = f'{IMGT_HLA_URL}{imgt_version}/wmda/hla_nom_g.txt'
+    df = pd.read_csv(ars_url, skiprows=6, names=["Locus", "A", "G"], sep=";").dropna()
+
+    df['A'] = df['A'].apply(lambda a: a.split('/'))
+    df = df.explode('A')
+    df['A'] = df['Locus'] + df['A']
+    df['G'] = df['Locus'] + df['G']
+
+    df['2d'] = df['A'].apply(get_2field_allele)
+    df['3d'] = df['A'].apply(get_3field_allele)
+
+    mg = df.drop_duplicates(['2d', 'G'])['2d'].value_counts()
+    multiple_g_list = mg[mg > 1].reset_index()['index'].to_list()
+
+    dup_g = df[df['2d'].isin(multiple_g_list)][['G', '2d']] \
+        .drop_duplicates() \
+        .groupby('2d', as_index=True).agg("/".join) \
+        .to_dict()['G']
+
+    df['lg'] = df['G'].apply(lambda a: ":".join(a.split(":")[0:2]) + "g")
+    df['lgx'] = df['G'].apply(lambda a: ":".join(a.split(":")[0:2]))
+
+    # Creating dictionaries with mac_code->ARS group mapping
+    df_g = pd.concat([
+        df[['2d', 'G']].rename(columns={'2d': 'A'}),
+        df[['3d', 'G']].rename(columns={'3d': 'A'}),
+        df[['A', 'G']]
+    ], ignore_index=True)
+    g_group = df_g.set_index('A')['G'].to_dict()
+
+    df_lg = pd.concat([
+        df[['2d', 'lg']].rename(columns={'2d': 'A'}),
+        df[['3d', 'lg']].rename(columns={'3d': 'A'}),
+        df[['A', 'lg']]
+    ])
+    lg_group = df_lg.set_index('A')['lg'].to_dict()
+
+    df_lgx = pd.concat([
+        df[['2d', 'lgx']].rename(columns={'2d': 'A'}),
+        df[['3d', 'lgx']].rename(columns={'3d': 'A'}),
+        df[['A', 'lgx']]
+    ])
+    lgx_group = df_lgx.set_index('A')['lgx'].to_dict()
+
+    db.save_dict(db_connection, table_name='dup_g', dictionary=dup_g, columns=('allele', 'g_group'))
+    db.save_dict(db_connection, table_name='g_group', dictionary=g_group, columns=('allele', 'g'))
+    db.save_dict(db_connection, table_name='lg_group', dictionary=lg_group, columns=('allele', 'lg'))
+    db.save_dict(db_connection, table_name='lgx_group', dictionary=lgx_group, columns=('allele', 'lgx'))
+
+    return dup_g, g_group, lg_group, lgx_group
+
+
+def generate_mac_codes(db_connection: sqlite3.Connection):
+    """
+    MAC files come in 2 different versions:
+
+    Martin: when they’re printed, the first is better for encoding and the
+    second is better for decoding. The entire list was maintained both as an
+    excel spreadsheet and also as a sybase database table. The excel was the
+    one that was printed and distributed.
+
+        **==> numer.v3.txt <==**
+
+        Sorted by the length and the the values in the list
+        ```
+        "LAST UPDATED: 09/30/20"
+        CODE	SUBTYPE
+
+        AB	01/02
+        AC	01/03
+        AD	01/04
+        AE	01/05
+        AG	01/06
+        AH	01/07
+        AJ	01/08
+        ```
+
+        **==> alpha.v3.txt <==**
+
+        Sorted by the code
+
+        ```
+        "LAST UPDATED: 10/01/20"
+        *	CODE	SUBTYPE
+
+            AA	01/02/03/05
+            AB	01/02
+            AC	01/03
+            AD	01/04
+            AE	01/05
+            AF	01/09
+            AG	01/06
+        ```
+
+    :param db_connection:
+    :param data_dir:
+    :return:
+    """
+    mac_table_name = 'mac_codes'
+    if not db.table_exists(db_connection, mac_table_name):
+        # Load the MAC file to a DataFrame
+        mac_url = 'https://hml.nmdp.org/mac/files/numer.v3.zip'
+        df_mac = pd.read_csv(mac_url, sep='\t', compression='zip', skiprows=3, names=['Code', 'Alleles'])
+        # Create a dict from code to alleles
+        mac = df_mac.set_index("Code")["Alleles"].to_dict()
+        # Save the mac dict to db
+        db.save_dict(db_connection, table_name=mac_table_name, dictionary=mac, columns=('code', 'alleles'))
+
+
+def generate_alleles_and_xx_codes(db_connection: sqlite3.Connection, imgt_version):
+    """
+    Checks to see if there's already an allele list file for the `imgt_version`
+    in the `data_dir` directory. If not, will download the file and create
+    a valid allele set and corresponding xx codes.
+
+    The format of the AlleleList file has a 6-line header with a header
+    on the 7th line
+    ```
+    # file: Allelelist.3290.txt
+    # date: 2017-07-10
+    # version: IPD-IMGT/HLA 3.29.0
+    # origin: https://github.com/ANHIG/IMGTHLA/Allelelist.3290.txt
+    # repository: https://raw.githubusercontent.com/ANHIG/IMGTHLA/Latest/Allelelist.3290.txt
+    # author: WHO, Steven G. E. Marsh (steven.marsh@ucl.ac.uk)
+    AlleleID,Allele
+    HLA00001,A*01:01:01:01
+    HLA02169,A*01:01:01:02N
+    HLA14798,A*01:01:01:03
+    HLA15760,A*01:01:01:04
+    HLA16415,A*01:01:01:05
+    HLA16417,A*01:01:01:06
+    HLA16436,A*01:01:01:07
+    ```
+
+    :param db_connection: Database connection to the sqlite database
+    :param imgt_version: IMGT database version
+    :return: None, updates self
+    """
+
+    if db.table_exists(db_connection, 'alleles'):
+        valid_alleles = db.load_set(db_connection, 'alleles')
+        xx_codes = db.load_dict(db_connection, 'xx_codes',
+                                ('allele_1d', 'allele_list'))
+        xx_codes = {k: v.split('/') for k, v in xx_codes.items()}
+        return valid_alleles, xx_codes
+
+    # Create a Pandas DataFrame from the mac_code list file
+    # Skip the header (first 6 lines) and use only the Allele column
+    if imgt_version == "Latest":
+        allele_list_url = f'{IMGT_HLA_URL}Latest/Allelelist.txt'
+    else:
+        allele_list_url = f'{IMGT_HLA_URL}Latest/Allelelist.{imgt_version}.txt'
+    allele_df = pd.read_csv(allele_list_url, header=6, usecols=['Allele'])
+
+    # Create a set of valid alleles
+    # All 2-field, 3-field and the original Alleles are considered valid alleles
+    allele_df['2d'] = allele_df['Allele'].apply(get_2field_allele)
+    allele_df['3d'] = allele_df['Allele'].apply(get_3field_allele)
+    valid_alleles = set(allele_df['Allele']). \
+        union(set(allele_df['2d'])). \
+        union(set(allele_df['3d']))
+
+    # Create xx_codes mapping from the unique alleles in 2-field column
+    xx_df = pd.DataFrame(allele_df['2d'].unique(), columns=['Allele'])
+    # Also create a first-field column
+    xx_df['1d'] = xx_df['Allele'].apply(lambda x: x.split(":")[0])
+    # xx_codes maps a first field name to its 2 field expansion
+    xx_codes = xx_df.groupby(['1d']) \
+        .apply(lambda x: list(x['Allele'])) \
+        .to_dict()
+
+    # Update xx codes with broads and splits
+    for broad, splits in broad_splits_mapping.items():
+        for split in splits:
+            if broad in xx_codes:
+                xx_codes[broad].extend(xx_codes[split])
+            else:
+                xx_codes[broad] = xx_codes[split]
+
+    # Save this version of the valid alleles and xx codes
+    db.save_set(db_connection, 'alleles', valid_alleles, 'allele')
+    flat_xx_codes = {k: '/'.join(v) for k, v in xx_codes.items()}
+    db.save_dict(db_connection, 'xx_codes', flat_xx_codes,
+                 ('allele_1d', 'allele_list'))
+
+    return valid_alleles, xx_codes

--- a/pyard/db.py
+++ b/pyard/db.py
@@ -1,0 +1,190 @@
+import pathlib
+import sqlite3
+from typing import Tuple, Dict, Union, Set, List
+
+
+def create_db_connection(data_dir, imgt_version, ro=False):
+    """
+    Create a  connection to a sqlite database in read-only mode
+    or read-write mode (default)
+
+    :param data_dir: The directory where the db is/will be created
+    :param imgt_version: IMGT db version
+    :param ro: Read-only mode ?
+    :return: db connection of type sqlite.Connection
+    """
+    # Set data directory where all the downloaded files will go
+    if data_dir is None:
+        data_dir = pathlib.Path.home() / ".pyard"
+
+    db_filename = f'{data_dir}/pyard-{imgt_version}.sqlite3'
+
+    if ro:
+        # If in read-only mode, make sure the db file exists
+        if not pathlib.Path(db_filename).exists():
+            raise RuntimeError(f'Reference Database {db_filename}  not available.')
+
+    # Create the data directory if it doesn't exist
+    if not pathlib.Path(db_filename).exists():
+        pathlib.Path(data_dir).mkdir(parents=True, exist_ok=True)
+
+    if ro:
+        # Open the database in read-only mode
+        file_uri = f'file:{db_filename}?mode=ro'
+    else:
+        # Open the database in read-only mode
+        file_uri = f'file:{db_filename}'
+
+    return sqlite3.connect(file_uri, uri=True)
+
+
+def table_exists(connection: sqlite3.Connection, table_name: str) -> bool:
+    """
+    Does the table exist in the database ?
+
+    :param connection: db connection of type sqlite.Connection
+    :param table_name: table in the sqlite db
+    :return: bool indicating whether table_name exists as a table
+    """
+    query = """SELECT count(*) from sqlite_master where type = 'table' and name = ?"""
+    cursor = connection.execute(query, (table_name,))
+    result = cursor.fetchone()
+    cursor.close()
+    return result[0] > 0
+
+
+def tables_exists(connection: sqlite3.Connection, table_names):
+    """
+    Do all the given tables exist in the database ?
+
+    :param connection: db connection of type sqlite.Connection
+    :param table_names: names of tables in the sqlite db
+    :return: bool indicating whether all table_names exists
+    """
+    return all([table_exists(connection, table_name) for table_name in table_names])
+
+
+def mac_code_to_alleles(connection: sqlite3.Connection, code: str) -> List[str]:
+    """
+    Look up the MAC code in the database and return corresponding list
+    of alleles.
+    :param connection: db connection of type sqlite.Connection
+    :param code: MAC code
+    :return: List of alleles
+    """
+    mac_query = "SELECT alleles from mac_codes where code = ?"
+    cursor = connection.execute(mac_query, (code,))
+    result = cursor.fetchone()
+    cursor.close()
+    if result:
+        alleles = result[0].split('/')
+    else:
+        alleles = None
+    return alleles
+
+
+def is_valid_mac_code(connection: sqlite3.Connection, code: str) -> bool:
+    """
+    Check db if the MAC code exists.
+
+    :param connection: db connection of type sqlite.Connection
+    :param code: MAC code
+    :return: code is MAC code ?
+    """
+    mac_query = "SELECT count(alleles) from mac_codes where code = ?"
+    cursor = connection.execute(mac_query, (code,))
+    result = cursor.fetchone()
+    cursor.close()
+    return result[0] > 0
+
+
+def save_dict(connection: sqlite3.Connection, table_name: str, dictionary: Union[Dict, Set], columns=Tuple[str, str]) -> bool:
+    """
+    Save the dictionary as a table with column names from columns Tuple.
+
+    :param connection: db connection of type sqlite.Connection
+    :param table_name: name of the table to create
+    :param dictionary: the dictionary which to take the key and values from
+    :param columns: column names in the table
+    :return: success status
+    """
+    cursor = connection.cursor()
+    create_table_sql = f"""CREATE TABLE {table_name} (
+                            {columns[0]} TEXT PRIMARY KEY,
+                            {columns[1]} TEXT NOT NULL
+                    )"""
+
+    # Create table
+    cursor.execute(create_table_sql)
+
+    # insert
+    cursor.executemany(f"INSERT INTO {table_name} VALUES (?, ?)", dictionary.items())
+
+    # commit transaction - writes to the db
+    connection.commit()
+    # close the cursor
+    cursor.close()
+
+    return True
+
+
+def save_set(connection: sqlite3.Connection, table_name: str, rows: Set, column: str) -> bool:
+    """
+    Save the set rows to the table table_name in the column
+
+    :param connection: db connection of type sqlite.Connection
+    :param table_name: name of the table to create
+    :param rows: set which will become the the column in the table
+    :param column: name of the column in the table
+    :return: success status
+    """
+    cursor = connection.cursor()
+    create_table_sql = f"""CREATE TABLE {table_name} (
+                            {column} TEXT PRIMARY KEY
+                    )"""
+
+    # Create table
+    cursor.execute(create_table_sql)
+
+    # insert
+    cursor.executemany(f"INSERT INTO {table_name} VALUES (?)", zip(rows, ))
+
+    # commit transaction - writes to the db
+    connection.commit()
+    # close the cursor
+    cursor.close()
+
+    return True
+
+
+def load_set(connection: sqlite3.Connection, table_name: str) -> Set:
+    """
+    Retrieve the first column of the table as a set
+
+    :param connection: db connection of type sqlite.Connection
+    :param table_name: name of the table to query
+    :return: set containing values from the column
+    """
+    cursor = connection.cursor()
+    select_all_query = f"SELECT * FROM {table_name}"
+    cursor.execute(select_all_query)
+    table_as_set = set(map(lambda t: t[0], cursor.fetchall()))
+    cursor.close()
+    return table_as_set
+
+
+def load_dict(connection: sqlite3.Connection, table_name: str, columns: Tuple[str, str]) -> Dict[str, str]:
+    """
+    Retrieve the values in columns as a name, value pair and create a dict.
+
+    :param connection: db connection of type sqlite.Connection
+    :param table_name: name of the table to query
+    :param columns: column names in the table
+    :return: a dict containing key,value pairs from the columns
+    """
+    cursor = connection.cursor()
+    select_all_query = f"SELECT {columns[0]}, {columns[1]} FROM {table_name}"
+    cursor.execute(select_all_query)
+    table_as_dict = {k: v for k, v in cursor.fetchall()}
+    cursor.close()
+    return table_as_dict

--- a/pyard/db.py
+++ b/pyard/db.py
@@ -1,6 +1,6 @@
 import pathlib
 import sqlite3
-from typing import Tuple, Dict, Union, Set, List
+from typing import Tuple, Dict, Set, List
 
 
 def create_db_connection(data_dir, imgt_version, ro=False):
@@ -53,7 +53,7 @@ def table_exists(connection: sqlite3.Connection, table_name: str) -> bool:
     return result[0] > 0
 
 
-def tables_exists(connection: sqlite3.Connection, table_names):
+def tables_exists(connection: sqlite3.Connection, table_names: List[str]):
     """
     Do all the given tables exist in the database ?
 
@@ -98,7 +98,8 @@ def is_valid_mac_code(connection: sqlite3.Connection, code: str) -> bool:
     return result[0] > 0
 
 
-def save_dict(connection: sqlite3.Connection, table_name: str, dictionary: Union[Dict, Set], columns=Tuple[str, str]) -> bool:
+def save_dict(connection: sqlite3.Connection, table_name: str,
+              dictionary: Dict[str, str], columns=Tuple[str, str]) -> bool:
     """
     Save the dictionary as a table with column names from columns Tuple.
 

--- a/pyard/pyard.py
+++ b/pyard/pyard.py
@@ -21,364 +21,63 @@
 #    > http://www.opensource.org/licenses/lgpl-license.php
 #
 import functools
-import logging
-import os
-import pathlib
-import pickle
+import gc
 import re
-from functools import partial
-from operator import is_not
-from typing import Dict
+from typing import Iterable
 
-import pandas as pd
-
-from .broad_splits import broad_splits_mapping
+from . import db
+from .data_repository import generate_ars_mapping, generate_mac_codes, generate_alleles_and_xx_codes
+from .db import is_valid_mac_code, mac_code_to_alleles
 from .smart_sort import smart_sort_comparator
-
-# The GitHub URL where IMGT HLA files are downloaded.
-IMGT_HLA_URL = 'https://raw.githubusercontent.com/ANHIG/IMGTHLA/'
-
-
-def is_mac(x):
-    return True if re.search(r":\D+", x) else False
-
 
 HLA_regex = re.compile("^HLA-")
 
-# List of expression characters
-expression_chars = ['N', 'Q', 'L', 'S']
-
-
-def get_n_field_allele(allele: str, n: int) -> str:
-    """
-    Given an HLA allele of >= n field, return n field allele.
-    Preserve the expression character if it exists
-
-    :param allele: Original allele
-    :param n: n number of fields to reduce to
-    :return: trimmed to n fields of the original allele
-    """
-    last_char = allele[-1]
-    fields = allele.split(':')
-    if last_char in expression_chars and len(fields) > n:
-        return ':'.join(fields[0:n]) + last_char
-    else:
-        return ':'.join(fields[0:n])
-
-
-def get_3field_allele(a: str) -> str:
-    return get_n_field_allele(a, 3)
-
-
-def get_2field_allele(a: str) -> str:
-    return get_n_field_allele(a, 2)
-
 
 class ARD(object):
-    """ ARD reduction for HLA """
+    """
+    ARD reduction for HLA
+    Allows reducing alleles and allele code(MAC) to G, lg and lgx levels.
+    """
 
-    def __init__(self, dbversion: str = 'Latest',
-                 load_mac_file: bool = True,
-                 verbose: bool = False,
+    def __init__(self, imgt_version: str = 'Latest',
                  remove_invalid: bool = True,
                  data_dir: str = None):
+        """
+        ARD will load valid alleles, xx codes and MAC mappings for the given
+        version of IMGT database, downloading and generating the database if
+        not already present.
 
-        self.mac = {}
-        self._verbose = verbose
-        self._dbversion = dbversion
-        self._load_mac_file = load_mac_file
+        :param imgt_version: IMGT HLA database version
+        :param remove_invalid: report only valid alleles for this version
+        :param data_dir: directory path to store cached data
+        """
         self._remove_invalid = remove_invalid
 
-        # Set data directory where all the downloaded files will go
-        if data_dir is None:
-            data_dir = pathlib.Path.home() / ".pyard"
-
-        data_dir = f'{data_dir}/{dbversion}'
-        pathlib.Path(data_dir).mkdir(parents=True, exist_ok=True)
+        # Create a database connection for writing
+        self.db_connection = db.create_db_connection(data_dir, imgt_version)
 
         # Load MAC codes
-        if load_mac_file:
-            self.generate_mac_codes(data_dir)
+        generate_mac_codes(self.db_connection)
         # Load Alleles and XX Codes
-        self.generate_alleles_and_xxcodes(dbversion, data_dir)
+        self.valid_alleles, self.xx_codes = generate_alleles_and_xx_codes(self.db_connection, imgt_version)
         # Load ARS mappings
-        self.generate_ars_mapping(data_dir)
+        self.dup_g, self._G, self._lg, self._lgx = generate_ars_mapping(self.db_connection, imgt_version)
 
-    def generate_ars_mapping(self, data_dir):
+        # Close the current read-write db connection
+        self.db_connection.close()
 
-        mapping_file = f'{data_dir}/ars_mapping.pickle'
-        if os.path.isfile(mapping_file):
-            with open(mapping_file, 'rb') as load_file:
-                ars_mapping = pickle.load(load_file)
-                self._G, self._lg, self._lgx, self.dup_g = ars_mapping
-                return
+        # reference data is read-only and can be frozen
+        gc.freeze()
 
-        ars_url = f'{IMGT_HLA_URL}{self._dbversion}/wmda/hla_nom_g.txt'
-        df = pd.read_csv(ars_url, skiprows=6, names=["Locus", "A", "G"], sep=";").dropna()
+        # Re-open the connection in read-only mode as we're not updating it anymore
+        self.db_connection = db.create_db_connection(data_dir, imgt_version, ro=True)
 
-        df['A'] = df['A'].apply(lambda a: a.split('/'))
-        df = df.explode('A')
-        df['A'] = df['Locus'] + df['A']
-        df['G'] = df['Locus'] + df['G']
-
-        df['2d'] = df['A'].apply(get_2field_allele)
-        df['3d'] = df['A'].apply(get_3field_allele)
-
-        mg = df.drop_duplicates(['2d', 'G'])['2d'].value_counts()
-        multiple_g_list = mg[mg > 1].reset_index()['index'].to_list()
-
-        self.dup_g = df[df['2d'].isin(multiple_g_list)][['G', '2d']] \
-            .drop_duplicates() \
-            .groupby('2d', as_index=True).agg("/".join) \
-            .to_dict()['G']
-
-        df['lg'] = df['G'].apply(lambda a: ":".join(a.split(":")[0:2]) + "g")
-        df['lgx'] = df['G'].apply(lambda a: ":".join(a.split(":")[0:2]))
-
-        # Creating dictionaries with allele->ARS group mapping
-        df_G = pd.concat([
-            df[['2d', 'G']].rename(columns={'2d': 'A'}),
-            df[['3d', 'G']].rename(columns={'3d': 'A'}),
-            df[['A', 'G']]
-        ], ignore_index=True)
-        self._G = df_G.set_index('A')['G'].to_dict()
-
-        df_lg = pd.concat([
-            df[['2d', 'lg']].rename(columns={'2d': 'A'}),
-            df[['3d', 'lg']].rename(columns={'3d': 'A'}),
-            df[['A', 'lg']]
-        ])
-        self._lg = df_lg.set_index('A')['lg'].to_dict()
-
-        df_lgx = pd.concat([
-            df[['2d', 'lgx']].rename(columns={'2d': 'A'}),
-            df[['3d', 'lgx']].rename(columns={'3d': 'A'}),
-            df[['A', 'lgx']]
-        ])
-        self._lgx = df_lgx.set_index('A')['lgx'].to_dict()
-
-        ars_mapping = (self._G, self._lg, self._lgx, self.dup_g)
-        with open(mapping_file, 'wb') as save_file:
-            pickle.dump(ars_mapping, save_file, protocol=pickle.HIGHEST_PROTOCOL)
-
-    def generate_mac_codes(self, data_dir):
+    def __del__(self):
         """
-        MAC files come in 2 different versions:
-
-        Martin: when they’re printed, the first is better for encoding and the
-        second is better for decoding. The entire list was maintained both as an
-        excel spreadsheet and also as a sybase database table. The excel was the
-        one that was printed and distributed.
-
-            **==> numer.v3.txt <==**
-
-            Sorted by the length and the the values in the list
-            ```
-            "LAST UPDATED: 09/30/20"
-            CODE	SUBTYPE
-
-            AB	01/02
-            AC	01/03
-            AD	01/04
-            AE	01/05
-            AG	01/06
-            AH	01/07
-            AJ	01/08
-            ```
-
-            **==> alpha.v3.txt <==**
-
-            Sorted by the code
-
-            ```
-            "LAST UPDATED: 10/01/20"
-            *	CODE	SUBTYPE
-
-                AA	01/02/03/05
-                AB	01/02
-                AC	01/03
-                AD	01/04
-                AE	01/05
-                AF	01/09
-                AG	01/06
-            ```
-
-        :param data_dir:
+        Close the db connection, when ARD instance goes away
         :return:
         """
-
-        mac_pickle = f'{data_dir}/mac.pickle'
-
-        if not os.path.isfile(mac_pickle):
-            if self.verbose:
-                logging.info("Downloading MAC file")
-            # Load the MAC file to a DataFrame
-            mac_url = 'https://hml.nmdp.org/mac/files/numer.v3.zip'
-            df_mac = pd.read_csv(mac_url, sep='\t', compression='zip', skiprows=3, names=['Code', 'Alleles'])
-            self.mac = df_mac.set_index("Code")["Alleles"].to_dict()
-
-            # Writing dict to pickle file
-            with open(mac_pickle, 'wb') as save_file:
-                pickle.dump(self.mac, save_file, protocol=pickle.HIGHEST_PROTOCOL)
-        else:
-            if self.verbose:
-                logging.info("Loading MAC file")
-            with open(mac_pickle, 'rb') as load_file:
-                self.mac = pickle.load(load_file)
-
-    def generate_alleles_and_xxcodes(self, dbversion: str, data_dir: str) -> None:
-        """
-        Checks to see if there's already an allele list file for the `dbversion`
-        in the `data_dir` directory. If not, will download the file and create
-        a valid allele set and corresponding xx codes.
-
-        The format of the AlleleList file has a 6-line header with a header
-        on the 7th line
-        ```
-        # file: Allelelist.3290.txt
-        # date: 2017-07-10
-        # version: IPD-IMGT/HLA 3.29.0
-        # origin: https://github.com/ANHIG/IMGTHLA/Allelelist.3290.txt
-        # repository: https://raw.githubusercontent.com/ANHIG/IMGTHLA/Latest/Allelelist.3290.txt
-        # author: WHO, Steven G. E. Marsh (steven.marsh@ucl.ac.uk)
-        AlleleID,Allele
-        HLA00001,A*01:01:01:01
-        HLA02169,A*01:01:01:02N
-        HLA14798,A*01:01:01:03
-        HLA15760,A*01:01:01:04
-        HLA16415,A*01:01:01:05
-        HLA16417,A*01:01:01:06
-        HLA16436,A*01:01:01:07
-        ```
-
-        :param dbversion: IMGT database version
-        :param data_dir: Data Directory to save the resulting files
-        :return: None, updates self
-        """
-
-        allele_file = f'{data_dir}/AlleleList.{dbversion}.pickle'
-        xx_codes_file = f'{data_dir}/XX_Codes.{dbversion}.pickle'
-
-        # If the pickled files already exist for the particular db version
-        # then reload the files without re-downloading
-        if pathlib.Path(allele_file).exists() and \
-                pathlib.Path(xx_codes_file).exists():
-            with open(allele_file, 'rb') as load_file:
-                self.valid_alleles = pickle.load(load_file)
-            with open(xx_codes_file, 'rb') as load_file:
-                self.xxcodes = pickle.load(load_file)
-            return
-
-        # Create a Pandas DataFrame from the allele list file
-        # Skip the header (first 6 lines) and use only the Allele
-        if dbversion == "Latest":
-            allele_list_url = f'{IMGT_HLA_URL}Latest/Allelelist.txt'
-        else:
-            allele_list_url = f'{IMGT_HLA_URL}Latest/Allelelist.{dbversion}.txt'
-        allele_df = pd.read_csv(allele_list_url, header=6, usecols=['Allele'])
-
-        # Create a set of valid alleles
-        # All 2-field, 3-field and the original Alleles are considered valid alleles
-        allele_df['2d'] = allele_df['Allele'].apply(get_2field_allele)
-        allele_df['3d'] = allele_df['Allele'].apply(get_3field_allele)
-        self.valid_alleles = set(allele_df['Allele']). \
-            union(set(allele_df['2d'])). \
-            union(set(allele_df['3d']))
-
-        # Create xxcodes mapping from the unique alleles in 2-field column
-        xx_df = pd.DataFrame(allele_df['2d'].unique(), columns=['Allele'])
-        # Also create a first-field column
-        xx_df['1d'] = xx_df['Allele'].apply(lambda x: x.split(":")[0])
-        # xxcodes maps a first field name to its 2 field expansion
-        self.xxcodes = xx_df.groupby(['1d']) \
-            .apply(lambda x: list(x['Allele'])) \
-            .to_dict()
-
-        # Update xx codes with broads and splits
-        for broad, splits in broad_splits_mapping.items():
-            for split in splits:
-                if broad in self.xxcodes:
-                    self.xxcodes[broad].extend(self.xxcodes[split])
-                else:
-                    self.xxcodes[broad] = self.xxcodes[split]
-
-        # Save this version of the valid alleles and xx codes
-        # Save alleles to pickle file
-        with open(allele_file, 'wb') as save_file:
-            pickle.dump(self.valid_alleles, save_file, protocol=pickle.HIGHEST_PROTOCOL)
-        # Save xx codes to pickle file
-        with open(xx_codes_file, 'wb') as save_file:
-            pickle.dump(self.xxcodes, save_file, protocol=pickle.HIGHEST_PROTOCOL)
-
-    @property
-    def dbversion(self) -> str:
-        """
-        Gets the dbversion of this ARS.
-
-        :return: The dbversion of this ARS.
-        :rtype: str
-        """
-        return self._dbversion
-
-    @property
-    def verbose(self) -> bool:
-        """
-        Gets the verbose of this ARS.
-
-        :return: The verbose of this ARS.
-        :rtype: bool
-        """
-        return self._verbose
-
-    @property
-    def load_mac_file(self) -> bool:
-        """
-        Gets the load_mac_file of this ARS.
-
-        :return: The load_mac_file of this ARS.
-        :rtype: bool
-        """
-        return self._load_mac_file
-
-    @property
-    def remove_invalid(self) -> bool:
-        """
-        Gets the remove_invalid of this ARS.
-
-        :return: The remove_invalid of this ARS.
-        :rtype: bool
-        """
-        return self._remove_invalid
-
-    @property
-    def G(self):
-        """
-        Gets the G of this ARS.
-
-        :return: The G of this ARS.
-        :rtype: Dict
-        """
-        return self._G
-
-    @property
-    def lg(self):
-        """
-        Gets the lg of this ARS.
-
-        :return: The lg of this ARS.
-        :rtype: Dict
-        """
-        return self._lg
-
-    @property
-    def lgx(self):
-        """
-        Gets the lgx of this ARS.
-
-        :return: The lgx of this ARS.
-        :rtype: Dict
-        """
-        return self._lgx
+        self.db_connection.close()
 
     @functools.lru_cache(maxsize=1000)
     def redux(self, allele: str, ars_type: str) -> str:
@@ -410,23 +109,23 @@ class ARD(object):
             if allele in self.dup_g:
                 return self.dup_g[allele]
             else:
-                return self.G[allele]
+                return self._G[allele]
         elif ars_type == "lg":
             if allele in self._lg:
-                return self.lg[allele]
+                return self._lg[allele]
             else:
-                # for 'lg' when allele is not in G group,
-                # return allele with only first 2 field
+                # for 'lg' when mac_code is not in G group,
+                # return mac_code with only first 2 field
                 return ':'.join(allele.split(':')[0:2]) + 'g'
         elif ars_type == "lgx":
             if allele in self._lgx:
-                return self.lgx[allele]
+                return self._lgx[allele]
             else:
-                # for 'lgx' when allele is not in G group,
-                # return allele with only first 2 field
+                # for 'lgx' when mac_code is not in G group,
+                # return mac_code with only first 2 field
                 return ':'.join(allele.split(':')[0:2])
         else:
-            if self.remove_invalid:
+            if self._remove_invalid:
                 if self._is_valid_allele(allele):
                     return allele
                 else:
@@ -474,11 +173,11 @@ class ARD(object):
 
         # handle XX codes
         # test that they are valid_alleles
-        if (is_mac(glstring) and glstring.split(":")[1] == "XX") and loc_name in self.xxcodes:
+        if (self.is_mac(glstring) and glstring.split(":")[1] == "XX") and loc_name in self.xx_codes:
             return self.redux_gl(
-                "/".join(sorted(self.xxcodes[loc_name], key=functools.cmp_to_key(smart_sort_comparator))), redux_type)
+                "/".join(sorted(self.xx_codes[loc_name], key=functools.cmp_to_key(smart_sort_comparator))), redux_type)
 
-        if is_mac(glstring) and code in self.mac:
+        if self.is_mac(glstring) and is_valid_mac_code(self.db_connection, code):
             if HLA_regex.search(glstring):
                 hla, allele_name = glstring.split("-")
                 loc_name, code = allele_name.split(":")
@@ -492,11 +191,34 @@ class ARD(object):
                                      redux_type)
         return self.redux(glstring, redux_type)
 
+    @staticmethod
+    def is_mac(gl: str) -> bool:
+        """
+        MAC has there are non-digit characters after the : character,
+        then it's a MAC.
+        :param gl: glstring to test if it has a MAC code
+        :return: bool
+        """
+        return re.search(r":\D+", gl) is not None
+
     def _is_valid_allele(self, allele):
+        """
+        Test if allele is valid in the current imgt database
+        :param allele: Allele to test
+        :return: bool to indicate if allele is valid
+        """
         return allele in self.valid_alleles
 
-    def _get_alleles(self, code, loc_name):
-        return filter(self._is_valid_allele, [f'{loc_name}:{a}' for a in self.mac[code].split('/')])
+    def _get_alleles(self, code, loc_name) -> Iterable[str]:
+        """
+        Look up allele code in database and generate alleles
+        :param code: allele code to look up
+        :param loc_name: locus name for alleles
+        :return: valid alleles corresponding to allele code
+        """
+        alleles = mac_code_to_alleles(self.db_connection, code)
+        return filter(self._is_valid_allele,
+                      [f'{loc_name}:{a}' for a in alleles])
 
     def isvalid(self, allele: str) -> bool:
         """
@@ -507,9 +229,7 @@ class ARD(object):
         :return: allele or empty
         :rtype: bool
         """
-        if not is_mac(allele):
-            # PERFORMANCE: use hash instead of allele in "list"
-            # return allele in self.valid_alleles
+        if not self.is_mac(allele):
             # Alleles ending with P or G are valid_alleles
             if allele.endswith(('P', 'G')):
                 # remove the last character
@@ -555,11 +275,11 @@ class ARD(object):
         :rtype: str
         """
         loc_name, code = allele.split(":")
-        if code in self.mac:
+        if HLA_regex.search(allele):
+            loc_name = loc_name.split("-")[1]
+        if is_valid_mac_code(self.db_connection, code):
             alleles = self._get_alleles(code, loc_name)
-            group = list(filter(partial(is_not, None),
-                                set([self.toG(allele=a)
-                                     for a in alleles])))
+            group = [self.toG(a) for a in alleles]
             if "X" in group:
                 return ''
             else:
@@ -577,29 +297,29 @@ class ARD(object):
         :return: ARS G reduced allele
         :rtype: str
         """
-        if allele in self.G:
+        if allele in self._G:
             if allele in self.dup_g:
                 return self.dup_g[allele]
             else:
-                return self.G[allele]
+                return self._G[allele]
         else:
             return "X"
 
-    def expand_mac(self, allele: str):
+    def expand_mac(self, mac_code: str):
         """
         Expands mac codes
 
-        :param allele: An HLA allele.
+        :param mac_code: An HLA allele.
         :type: str
         :return: List
         :rtype: List
         """
-        loc_name, code = allele.split(":")
-        loc, n = loc_name.split("*")
-        if len(loc.split("-")) == 2:
-            loc_name = loc_name.split("-")[1]
+        loc_name, code = mac_code.split(":")
+        if is_valid_mac_code(self.db_connection, code):
+            if HLA_regex.search(mac_code):
+                loc_name = loc_name.split("-")[1]
+                return ['HLA-' + a for a in self._get_alleles(code, loc_name)]
+            else:
+                return list(self._get_alleles(code, loc_name))
 
-        if code in self.mac:
-            return self._get_alleles(code, loc_name)
-        else:
-            return ''
+        return ''

--- a/pyard/pyard.py
+++ b/pyard/pyard.py
@@ -114,15 +114,15 @@ class ARD(object):
             if allele in self._lg:
                 return self._lg[allele]
             else:
-                # for 'lg' when mac_code is not in G group,
-                # return mac_code with only first 2 field
+                # for 'lg' when allele is not in G group,
+                # return allele with only first 2 field
                 return ':'.join(allele.split(':')[0:2]) + 'g'
         elif ars_type == "lgx":
             if allele in self._lgx:
                 return self._lgx[allele]
             else:
-                # for 'lgx' when mac_code is not in G group,
-                # return mac_code with only first 2 field
+                # for 'lgx' when allele is not in G group,
+                # return allele with only first 2 field
                 return ':'.join(allele.split(':')[0:2])
         else:
             if self._remove_invalid:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.0
+current_version = 0.3.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ test_requirements = [
 
 setup(
     name='py-ard',
-    version='0.2.0',
+    version='0.3.0',
     description="ARD reduction for HLA with python",
     long_description=readme + '\n\n' + history,
     author="CIBMTR",

--- a/tests/test_pyard.py
+++ b/tests/test_pyard.py
@@ -46,15 +46,12 @@ class TestPyArd(unittest.TestCase):
         self.assertIsInstance(self.ard, ARD)
 
     def test_no_mac(self):
-        ard_no_mac = ARD(self.db_version, data_dir='/tmp/3290', load_mac_file=False)
-        self.assertIsInstance(ard_no_mac, ARD)
-        self.assertEqual(len(ard_no_mac.mac.keys()), 0)
-        self.assertEqual(ard_no_mac.redux("A*01:01:01", 'G'), "A*01:01:01G")
-        self.assertEqual(ard_no_mac.redux("A*01:01:01", 'lg'), "A*01:01g")
-        self.assertEqual(ard_no_mac.redux("A*01:01:01", 'lgx'), "A*01:01")
-        self.assertEqual(ard_no_mac.redux("HLA-A*01:01:01", 'G'), "HLA-A*01:01:01G")
-        self.assertEqual(ard_no_mac.redux("HLA-A*01:01:01", 'lg'), "HLA-A*01:01g")
-        self.assertEqual(ard_no_mac.redux("HLA-A*01:01:01", 'lgx'), "HLA-A*01:01")
+        self.assertEqual(self.ard.redux("A*01:01:01", 'G'), "A*01:01:01G")
+        self.assertEqual(self.ard.redux("A*01:01:01", 'lg'), "A*01:01g")
+        self.assertEqual(self.ard.redux("A*01:01:01", 'lgx'), "A*01:01")
+        self.assertEqual(self.ard.redux("HLA-A*01:01:01", 'G'), "HLA-A*01:01:01G")
+        self.assertEqual(self.ard.redux("HLA-A*01:01:01", 'lg'), "HLA-A*01:01g")
+        self.assertEqual(self.ard.redux("HLA-A*01:01:01", 'lgx'), "HLA-A*01:01")
 
     def test_remove_invalid(self):
         self.assertEqual(self.ard.redux("A*01:01:01", 'G'), "A*01:01:01G")
@@ -116,3 +113,21 @@ class TestPyArd(unittest.TestCase):
                           ':360'
         gl = self.ard.redux_gl('B*40:XX', 'G')
         self.assertEqual(gl, expanded_string)
+
+    def test_expand_mac(self):
+        mac_ab_expanded = ['A*01:01', 'A*01:02']
+        self.assertEqual(self.ard.expand_mac('A*01:AB'), mac_ab_expanded)
+
+        mac_hla_ab_expanded = ['HLA-A*01:01', 'HLA-A*01:02']
+        self.assertEqual(self.ard.expand_mac('HLA-A*01:AB'), mac_hla_ab_expanded)
+
+        mac_ac_expanded = ['A*01:01', 'A*01:03']
+        self.assertEqual(self.ard.expand_mac('A*01:AC'), mac_ac_expanded)
+
+        mac_hla_ac_expanded = ['HLA-A*01:01', 'HLA-A*01:03']
+        self.assertEqual(self.ard.expand_mac('HLA-A*01:AC'), mac_hla_ac_expanded)
+
+    def test_mac_toG(self):
+        g_alleles = 'A*01:01:01G/A*01:03:01G'
+        self.assertEqual(self.ard.mac_toG('A*01:AC'), g_alleles)
+        self.assertEqual(self.ard.mac_toG('A*01:AB'), '')


### PR DESCRIPTION
Use sqlite3 database for data 

   - Move data generation code to `data_repository.py`
   - `db.py` saves/load tables of data, retrieve MAC code
   - Bump version: 0.2.0 → 0.3.0

Offload MAC codes from memory to sqlite3 database (natively supported by Python) to reduce
memory footprint. All MAC lookups happen through the db. The alleles and G group expansions
are still held in memory.

In addition, all generated data is saved as tables in the same database. This leads to one
file for storing all reference data in a standard format.

This led to drastic reduction in memory usage and startup time.

|Version |First Time| Prebuilt Data|
|:--|--:|--:|
| 0.1.0 | 10.5 sec |  4.92 sec|
| 0.2.0 | 814 msec |  598 msec|
| 0.3.0 | 24.1 msec | 24.7 msec |


Heap memory used by ARD reference data after `ard = pyard.ARD(3290)`

|Version |Memory (MB) |
|:--|--:|
| 0.1.0 | 2977.86 MB |
| 0.2.0 | 420.76 MB |
| 0.3.0 | 3.74 MB |

Fixes #44 