### PR TITLE
Update pandas 1.1.4

### DIFF
--- a/pyard/__init__.py
+++ b/pyard/__init__.py
@@ -24,4 +24,4 @@
 from .pyard import ARD
 
 __author__ = """NMDP Bioinformatics"""
-__version__ = '0.4.0'
+__version__ = '0.4.1'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.0
+current_version = 0.4.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ test_requirements = [
 
 setup(
     name='py-ard',
-    version='0.4.0',
+    version='0.4.1',
     description="ARD reduction for HLA with python",
     long_description=readme + '\n\n' + history,
     author="CIBMTR",

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 requirements = [
-    'pandas==1.1.2'
+    'pandas>=1.1.4'
 ]
 
 
@@ -62,6 +62,7 @@ setup(
         'License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)',
         'Natural Language :: English',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     test_suite='tests',
     tests_require=test_requirements,


### PR DESCRIPTION
Update pandas 1.1.4

   - Pandas `1.1.2` doesn't work with Python 3.9. Upgrade Pandas to `1.1.4` which works with Python 3.8 and 3.9
   -  Bump version: 0.4.0 → 0.4.1 