### PR TITLE
Fix serological mapping

### DIFF
--- a/pyard/__init__.py
+++ b/pyard/__init__.py
@@ -24,4 +24,4 @@
 from .pyard import ARD
 
 __author__ = """NMDP Bioinformatics"""
-__version__ = '0.4.1'
+__version__ = '0.5.0'

--- a/pyard/db.py
+++ b/pyard/db.py
@@ -79,7 +79,7 @@ def mac_code_to_alleles(connection: sqlite3.Connection, code: str) -> List[str]:
     if result:
         alleles = result[0].split('/')
     else:
-        alleles = None
+        alleles = []
     return alleles
 
 
@@ -98,7 +98,7 @@ def serology_to_alleles(connection: sqlite3.Connection, serology: str) -> List[s
     if result:
         alleles = result[0].split('/')
     else:
-        alleles = None
+        alleles = []
     return alleles
 
 

--- a/pyard/pyard.py
+++ b/pyard/pyard.py
@@ -238,7 +238,9 @@ class ARD(object):
         :param allele: Allele to test
         :return: bool to indicate if allele is valid
         """
-        return allele in self.valid_alleles
+        if self._remove_invalid:
+            return allele in self.valid_alleles
+        return True
 
     def _get_alleles(self, code, loc_name) -> Iterable[str]:
         """
@@ -248,12 +250,18 @@ class ARD(object):
         :return: valid alleles corresponding to allele code
         """
         alleles = mac_code_to_alleles(self.db_connection, code)
-        return filter(self._is_valid_allele,
-                      [f'{loc_name}:{a}' for a in alleles])
+        if self._remove_invalid:
+            return filter(self._is_valid_allele,
+                          [f'{loc_name}:{a}' for a in alleles])
+        else:
+            return [f'{loc_name}:{a}' for a in alleles]
 
     def _get_alleles_from_serology(self, serology) -> Iterable[str]:
         alleles = db.serology_to_alleles(self.db_connection, serology)
-        return filter(self._is_valid_allele, alleles)
+        if self._remove_invalid:
+            return filter(self._is_valid_allele, alleles)
+        else:
+            return alleles
 
     def isvalid(self, allele: str) -> bool:
         """

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.1
+current_version = 0.5.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ test_requirements = [
 
 setup(
     name='py-ard',
-    version='0.4.1',
+    version='0.5.0',
     description="ARD reduction for HLA with python",
     long_description=readme + '\n\n' + history,
     author="CIBMTR",

--- a/tests/features/serology.feature
+++ b/tests/features/serology.feature
@@ -12,13 +12,9 @@ Feature: Serology
 
     Examples: Valid A serology typings
       | Serology | Level | Redux Allele                                                |
-      | A*10     | G     | A*26:01:01G/A*26:10/A*26:15/A*26:92/A*66:01:01G/A*66:03:01G |
-      | A*10     | lg    | A*26:01g/A*26:10g/A*26:15g/A*26:92g/A*66:01g/A*66:03g       |
-      | A*10     | lgx   | A*26:01/A*26:10/A*26:15/A*26:92/A*66:01/A*66:03             |
-
-    Examples: With HLA- prefix
-      | Serology    | Level | Redux Allele                                                                        |
-      | HLA-A*10    | G     | HLA-A*26:01:01G/HLA-A*26:10/HLA-A*26:15/HLA-A*26:92/HLA-A*66:01:01G/HLA-A*66:03:01G |
-      | HLA-B*15:03 | G     | HLA-B*15:03:01G                                                                     |
-      | HLA-DQB1*1  | G     | HLA-DQB1*06:11:01/HLA-DQB1*06:11:02/HLA-DQB1*06:11:03/HLA-DQB1*06:12                |
-      | HLA-DQB1*1  | lg    | HLA-DQB1*06:11g/HLA-DQB1*06:12g                                                     |
+      | A10      | G     | A*26:01:01G/A*26:10/A*26:15/A*26:92/A*66:01:01G/A*66:03:01G |
+      | A10      | lg    | A*26:01g/A*26:10g/A*26:15g/A*26:92g/A*66:01g/A*66:03g       |
+      | A10      | lgx   | A*26:01/A*26:10/A*26:15/A*26:92/A*66:01/A*66:03             |
+      | A19      | G     | A*02:65/A*33:09                                             |
+      | DR1403   | G     | DRB1*14:03:01/DRB1*14:03:02                                 |
+      | DR2      | G     | DRB1*15:08/DRB1*16:03                                       |


### PR DESCRIPTION
Serological Mapping
 - does not have `*`
 - DRs, DQs, DPs are flattened to 2 letters
 - Reference http://hla.alleles.org/antigens/recognised_serology.html

Bump version: 0.4.1 → 0.5.0 

Closes #62 