### PR TITLE
Fix MAC codes with allelic expansion

### DIFF
--- a/pyard/__init__.py
+++ b/pyard/__init__.py
@@ -24,4 +24,4 @@
 from .pyard import ARD
 
 __author__ = """NMDP Bioinformatics"""
-__version__ = '0.5.0'
+__version__ = '0.5.1'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.0
+current_version = 0.5.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ test_requirements = [
 
 setup(
     name='py-ard',
-    version='0.5.0',
+    version='0.5.1',
     description="ARD reduction for HLA with python",
     long_description=readme + '\n\n' + history,
     author="CIBMTR",

--- a/tests/features/mac.feature
+++ b/tests/features/mac.feature
@@ -6,9 +6,17 @@ Feature: MAC (Multiple Allele Code)
     When reducing on the <Level> level (ambiguous)
     Then the reduced allele is found to be <Redux Allele>
 
-    Examples:
+
+    Examples: MACs with group expansions
       | Allele      | Level | Redux Allele                |
       | A*01:AB     | G     | A*01:01:01G/A*01:02         |
       | A*01:AB     | lgx   | A*01:01/A*01:02             |
       | HLA-A*01:AB | G     | HLA-A*01:01:01G/HLA-A*01:02 |
       | HLA-A*01:AB | lgx   | HLA-A*01:01/HLA-A*01:02     |
+
+
+    Examples: MACs with allelic expansions
+      | Allele     | Level | Redux Allele      |
+      | B*08:ASXJP | G     | B*08:01:01G       |
+      | B*08:ASXJP | lgx   | B*08:01           |
+      | C*07:HTGM  | lgx   | C*07:01/C*07:150Q |


### PR DESCRIPTION
 Depending upon whether the expanded alleles for a MAC code contains a `:` or not, the expansion should be treated differently.

```
>>> import pyard
>>> ard = pyard.ARD()
>>> ard.expand_mac('B*08:ASXJP')
['B*08:01', 'B*08:19N', 'B*08:109', 'B*08:173']

>>> ard.redux_gl('B*08:ASXJP', 'G')
'B*08:01:01G'
>>> ard.redux_gl('B*08:ASXJP', 'lgx')
'B*08:01'

>>> ard.redux_gl('B*08:AB', 'lgx')
'B*08:01/B*08:02'
```

Closes #64 