### PR TITLE
Version 2 Nomenclature and pyard tools

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,3 +88,31 @@ Example
     # 'HLA-A*24:19g/HLA-A*24:22g^HLA-A*26:01g/HLA-A*26:10g/HLA-A*26:15g/HLA-A*26:92g/HLA-A*66:01g/HLA-A*66:03g'
 
 
+Command Line Tools
+------------------
+
+.. code-block:: bash
+
+    # Import the latest IMGT database
+    $ pyard-import
+    Created Latest py-ard database
+
+    # Import particular version of IMGT database
+    $ pyard-import --import-db-version 3.29.0
+    Created py-ard version 3290 database
+
+    # Import particular version of IMGT database and
+    # replace the v2 to v3 mapping table
+    $ pyard-import --import-db-version 3.29.0 --v2-to-v3-mapping map2to3.csv
+    Created py-ard version 3290 database
+    Updated v2_mapping table with 'map2to3.csv' mapping file.
+
+    # Reduce a gl string from command line
+    $ pyard --gl 'A*01:AB' -r lgx
+    A*01:01/A*01:02
+
+    $ pyard --gl 'DRB1*08:XX' -r G
+    DRB1*08:01:01G/DRB1*08:02:01G/DRB1*08:03:02G/DRB1*08:04:01G/DRB1*08:05/ ...
+
+    $ pyard -v 3290 --gl 'A1' -r lgx
+    A*01:01/A*01:02/A*01:03/A*01:06/A*01:07/A*01:08/A*01:09/A*01:10/A*01:12/ ...

--- a/pyard/__init__.py
+++ b/pyard/__init__.py
@@ -24,4 +24,4 @@
 from .pyard import ARD
 
 __author__ = """NMDP Bioinformatics"""
-__version__ = '0.5.1'
+__version__ = '0.6.0'

--- a/pyard/data_repository.py
+++ b/pyard/data_repository.py
@@ -1,3 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+#    py-ard
+#    Copyright (c) 2020 Be The Match operated by National Marrow Donor Program. All Rights Reserved.
+#
+#    This library is free software; you can redistribute it and/or modify it
+#    under the terms of the GNU Lesser General Public License as published
+#    by the Free Software Foundation; either version 3 of the License, or (at
+#    your option) any later version.
+#
+#    This library is distributed in the hope that it will be useful, but WITHOUT
+#    ANY WARRANTY; with out even the implied warranty of MERCHANTABILITY or
+#    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+#    License for more details.
+#
+#    You should have received a copy of the GNU Lesser General Public License
+#    along with this library;  if not, write to the Free Software Foundation,
+#    Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA.
+#
+#    > http://www.fsf.org/licensing/licenses/lgpl.html
+#    > http://www.opensource.org/licenses/lgpl-license.php
+#
 import functools
 import sqlite3
 
@@ -299,3 +321,25 @@ def generate_serology_mapping(db_connection: sqlite3.Connection, imgt_version):
         # Save the serology mapping to db
         db.save_dict(db_connection, table_name='serology_mapping',
                      dictionary=sero_mapping, columns=('serology', 'allele_list'))
+
+
+def generate_v2_to_v3_mapping(db_connection: sqlite3.Connection, imgt_version):
+    if not db.table_exists(db_connection, 'v2_mapping'):
+        # TODO: Create mapping table using both the allele list history and
+        #  deleted alleles as reference.
+        # Temporary Example
+        v2_to_v3_example = {
+            "A*0104": "A*01:04N",
+            "A*0105N": "A*01:04N",
+            "A*0111": "A*01:11N",
+            "A*01123": "A*01:123N",
+            "A*0115": "A*01:15N",
+            "A*0116": "A*01:16N",
+            "A*01160": "A*01:160N",
+            "A*01162": "A*01:162N",
+            "A*01178": "A*01:178N",
+            "A*01179": "A*01:179N",
+            "DRB5*02ZB": "DRB5*02:UTV",
+        }
+        db.save_dict(db_connection, table_name='v2_mapping',
+                     dictionary=v2_to_v3_example, columns=('v2', 'v3'))

--- a/pyard/db.py
+++ b/pyard/db.py
@@ -1,3 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+#    py-ard
+#    Copyright (c) 2020 Be The Match operated by National Marrow Donor Program. All Rights Reserved.
+#
+#    This library is free software; you can redistribute it and/or modify it
+#    under the terms of the GNU Lesser General Public License as published
+#    by the Free Software Foundation; either version 3 of the License, or (at
+#    your option) any later version.
+#
+#    This library is distributed in the hope that it will be useful, but WITHOUT
+#    ANY WARRANTY; with out even the implied warranty of MERCHANTABILITY or
+#    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+#    License for more details.
+#
+#    You should have received a copy of the GNU Lesser General Public License
+#    along with this library;  if not, write to the Free Software Foundation,
+#    Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA.
+#
+#    > http://www.fsf.org/licensing/licenses/lgpl.html
+#    > http://www.opensource.org/licenses/lgpl-license.php
+#
 import pathlib
 import sqlite3
 from typing import Tuple, Dict, Set, List
@@ -92,7 +114,7 @@ def serology_to_alleles(connection: sqlite3.Connection, serology: str) -> List[s
     :return: List of alleles
     """
     serology_query = "SELECT allele_list from serology_mapping where serology = ?"
-    cursor = connection.execute(serology_query, (serology, ))
+    cursor = connection.execute(serology_query, (serology,))
     result = cursor.fetchone()
     cursor.close()
     if result:
@@ -100,6 +122,23 @@ def serology_to_alleles(connection: sqlite3.Connection, serology: str) -> List[s
     else:
         alleles = []
     return alleles
+
+
+def v2_to_v3_allele(connection: sqlite3.Connection, v2_allele: str) -> str:
+    """
+    Look up V3 version of the allele in the database.
+
+    :param connection: db connection of type sqlite.Connection
+    :param v2_allele: V2 allele
+    :return: V3 allele
+    """
+    v2_query = "SELECT v3 from v2_mapping where v2 = ?"
+    cursor = connection.execute(v2_query, (v2_allele,))
+    result = cursor.fetchone()
+    cursor.close()
+    if result:
+        return result[0]
+    return ''
 
 
 def is_valid_mac_code(connection: sqlite3.Connection, code: str) -> bool:

--- a/pyard/smart_sort.py
+++ b/pyard/smart_sort.py
@@ -25,6 +25,7 @@ import functools
 import re
 
 expr_regex = re.compile('[NQLSGg]')
+glstring_chars = re.compile('[/|+^~]')
 
 
 @functools.lru_cache(maxsize=1000)
@@ -41,6 +42,10 @@ def smart_sort_comparator(a1, a2):
 
     # Check to see if they are the same alleles
     if a1 == a2:
+        return 0
+
+    # Ignore GL String matches
+    if re.search(glstring_chars, a1) or re.search(glstring_chars, a2):
         return 0
 
     # remove any non-numerics
@@ -92,4 +97,3 @@ def smart_sort_comparator(a1, a2):
 
     # All fields are considered equal after 4th field
     return 0
-

--- a/pyard/smart_sort.py
+++ b/pyard/smart_sort.py
@@ -44,9 +44,12 @@ def smart_sort_comparator(a1, a2):
     if a1 == a2:
         return 0
 
-    # Ignore GL String matches
+    # GL String matches
     if re.search(glstring_chars, a1) or re.search(glstring_chars, a2):
-        return 0
+        if a1 > a2:
+            return 1
+        else:
+            return -1
 
     # remove any non-numerics
     a1 = re.sub(expr_regex, '', a1)

--- a/scripts/pyard
+++ b/scripts/pyard
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+#    py-ard
+#    Copyright (c) 2020 Be The Match operated by National Marrow Donor Program. All Rights Reserved.
+#
+#    This library is free software; you can redistribute it and/or modify it
+#    under the terms of the GNU Lesser General Public License as published
+#    by the Free Software Foundation; either version 3 of the License, or (at
+#    your option) any later version.
+#
+#    This library is distributed in the hope that it will be useful, but WITHOUT
+#    ANY WARRANTY; with out even the implied warranty of MERCHANTABILITY or
+#    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+#    License for more details.
+#
+#    You should have received a copy of the GNU Lesser General Public License
+#    along with this library;  if not, write to the Free Software Foundation,
+#    Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA.
+#
+#    > http://www.fsf.org/licensing/licenses/lgpl.html
+#    > http://www.opensource.org/licenses/lgpl-license.php
+#
+import argparse
+
+import pyard
+
+
+def get_imgt_version(imgt_version):
+    if imgt_version:
+        version = imgt_version.replace('.', '')
+        if version.isdigit():
+            return version
+        raise RuntimeError(f"{imgt_version} is not a valid IMGT database version number")
+    return None
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        usage="""[-v <IMGT DB Version>] [gl-string redux_type]""",
+        description="""py-ard tool to redux GL String"""
+    )
+    parser.add_argument(
+        "-v",
+        "--imgt-version",
+        dest="imgt_version"
+    )
+    parser.add_argument(
+        "--gl",
+        required=True,
+        dest="gl_string"
+    )
+    parser.add_argument(
+        "-r",
+        choices=['G', 'lg', 'lgx'],
+        required=True,
+        dest="redux_type"
+    )
+
+    args = parser.parse_args()
+
+    imgt_version = get_imgt_version(args.imgt_version)
+    if imgt_version:
+        ard = pyard.ARD(imgt_version)
+    else:
+        ard = pyard.ARD()
+
+    print(ard.redux_gl(args.gl_string, args.redux_type))
+    del ard

--- a/scripts/pyard-import
+++ b/scripts/pyard-import
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+#    py-ard
+#    Copyright (c) 2020 Be The Match operated by National Marrow Donor Program. All Rights Reserved.
+#
+#    This library is free software; you can redistribute it and/or modify it
+#    under the terms of the GNU Lesser General Public License as published
+#    by the Free Software Foundation; either version 3 of the License, or (at
+#    your option) any later version.
+#
+#    This library is distributed in the hope that it will be useful, but WITHOUT
+#    ANY WARRANTY; with out even the implied warranty of MERCHANTABILITY or
+#    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+#    License for more details.
+#
+#    You should have received a copy of the GNU Lesser General Public License
+#    along with this library;  if not, write to the Free Software Foundation,
+#    Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA.
+#
+#    > http://www.fsf.org/licensing/licenses/lgpl.html
+#    > http://www.opensource.org/licenses/lgpl-license.php
+#
+import argparse
+import pathlib
+
+import pyard
+from pyard import db
+import pandas as pd
+
+
+def get_imgt_version(imgt_version):
+    if imgt_version:
+        version = imgt_version.replace('.', '')
+        if version.isdigit():
+            return version
+        raise RuntimeError(f"{imgt_version} is not a valid IMGT database version number")
+    return None
+
+
+def get_data_dir(data_dir):
+    if data_dir:
+        path = pathlib.Path(data_dir)
+        if not path.exists() or not path.is_dir():
+            raise RuntimeError(f"{data_dir} is not a valid directory")
+    return data_dir
+
+
+def get_v2_v3_mapping(v2_v3_mapping):
+    if v2_v3_mapping:
+        path = pathlib.Path(v2_v3_mapping)
+        if not path.exists() or not path.is_file():
+            raise RuntimeError(f"{data_dir} is not a valid file")
+        df = pd.read_csv(path, names=['v2', 'v3'])
+        return df.set_index('v2')['v3'].to_dict()
+    return None
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        usage="""[--import-db-version <IMGT DB Version>]\
+        [--data-dir <directory for db file>]\
+        [--v2-to-v3-mapping <V2 to V3 mapping CSV file>]""",
+        description="""py-ard tool to generate reference SQLite database.\
+        Allows updating db with custom mappings."""
+    )
+    parser.add_argument(
+        "--import-db-version",
+        dest="imgt_version"
+    )
+    parser.add_argument(
+        "--data-dir",
+        dest="data_dir"
+    )
+    parser.add_argument(
+        "--v2-to-v3-mapping",
+        dest="v2_v3_mapping"
+    )
+    args = parser.parse_args()
+
+    imgt_version = get_imgt_version(args.imgt_version)
+    # print(imgt_version)
+
+    data_dir = get_data_dir(args.data_dir)
+    # print(data_dir)
+
+    v2_to_v3_dict = get_v2_v3_mapping(args.v2_v3_mapping)
+    # print(len(v2_to_v3_dict))
+
+    if imgt_version:
+        ard = pyard.ARD(imgt_version=imgt_version, data_dir=data_dir)
+        print(f"Created py-ard version {imgt_version} database")
+    else:
+        ard = pyard.ARD(data_dir=data_dir)
+        print(f"Created Latest py-ard database")
+    del ard
+
+    if v2_to_v3_dict:
+        db_connection = db.create_db_connection(data_dir, imgt_version, ro=False)
+        db.save_dict(db_connection, table_name='v2_mapping',
+                     dictionary=v2_to_v3_dict, columns=('v2', 'v3'))
+        print(f"Updated v2_mapping table with '{args.v2_v3_mapping}' mapping file.")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.1
+current_version = 0.6.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -35,15 +35,15 @@ requirements = [
     'pandas>=1.1.4'
 ]
 
-
 test_requirements = [
-    # TODO: put package test requirements here
+    'behave==1.2.6',
+    'PyHamcrest==2.0.2'
 ]
 
 setup(
     name='py-ard',
     version='0.5.1',
-    description="ARD reduction for HLA with python",
+    description="ARD reduction for HLA with Python",
     long_description=readme + '\n\n' + history,
     author="CIBMTR",
     author_email='cibmtr-pypi@nmdp.org',
@@ -51,7 +51,11 @@ setup(
     packages=[
         'pyard',
     ],
-    package_dir={'pyard': 'pyard'},
+    provides=['pyard'],
+    scripts=[
+        'scripts/pyard',
+        'scripts/pyard-import',
+    ],
     install_requires=requirements,
     license="LGPL 3.0",
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ test_requirements = [
 
 setup(
     name='py-ard',
-    version='0.5.1',
+    version='0.6.0',
     description="ARD reduction for HLA with Python",
     long_description=readme + '\n\n' + history,
     author="CIBMTR",

--- a/tests/features/mac.feature
+++ b/tests/features/mac.feature
@@ -16,7 +16,9 @@ Feature: MAC (Multiple Allele Code)
 
 
     Examples: MACs with allelic expansions
-      | Allele     | Level | Redux Allele      |
-      | B*08:ASXJP | G     | B*08:01:01G       |
-      | B*08:ASXJP | lgx   | B*08:01           |
-      | C*07:HTGM  | lgx   | C*07:01/C*07:150Q |
+      | Allele          | Level | Redux Allele                                |
+      | B*08:ASXJP      | G     | B*08:01:01G                                 |
+      | B*08:ASXJP      | lgx   | B*08:01                                     |
+      | C*07:HTGM       | lgx   | C*07:01/C*07:150Q                           |
+      | A*01:AC+A*01:AB | G     | A*01:01:01G/A*01:02+A*01:01:01G/A*01:03:01G |
+      | A*01:01+A*01:AB | G     | A*01:01:01G+A*01:01:01G/A*01:02             |

--- a/tests/features/version2.feature
+++ b/tests/features/version2.feature
@@ -1,0 +1,16 @@
+Feature: Version 2 Nomenclature
+
+  py-ard is able to reduce version 2 HLA nomenclature.
+
+  Scenario Outline:
+
+    Given the version 2 typing is <Version2>
+    When reducing on the <Level> level (ambiguous)
+    Then the reduced allele is found to be <Redux Allele>
+
+
+    Examples: Valid A serology typings
+      | Version2  | Level | Redux Allele                                                   |
+      | A*0105N   | G     | A*01:01:01G                                                    |
+      | A*0111    | G     | A*01:11N                                                       |
+      | DRB5*02ZB | G     | DRB5*01:02:01G/DRB5*01:03/DRB5*02:02:01G/DRB5*02:03/DRB5*02:04 |

--- a/tests/steps/redux_allele.py
+++ b/tests/steps/redux_allele.py
@@ -27,3 +27,8 @@ def step_impl(context, redux_allele):
 @given("the serology typing is {serology}")
 def step_impl(context, serology):
     context.allele = serology
+
+
+@given("the version 2 typing is {v2_allele}")
+def step_impl(context, v2_allele):
+    context.allele = v2_allele


### PR DESCRIPTION
Support Version 2 Nomenclature
  - Add initial support for importing V2 into db
  - Lookup V2 nomenclature

Tool
  - Command Line Tool `py-ard-import` to import a new database
  - Command Line Tool `py-ard` to reduce a GL String

Handle GL Strings for smart sorts
Fixes #66 

Bump version: 0.5.1 → 0.6.0 