### PR TITLE
Shortnulls

### DIFF
--- a/pyard/data_repository.py
+++ b/pyard/data_repository.py
@@ -323,32 +323,32 @@ def generate_alleles_and_xx_codes_and_who(db_connection: sqlite3.Connection, img
     # DRB4*01:03N | DRB4*01:03:01:02N/DRB4*01:03:01:13N 
     # DRB5*01:08N | DRB5*01:08:01N/DRB5*01:08:02N 
     shortnulls = dict()
-    for k in who_group:
-        if k[-1] not in expression_chars and k[-1] not in ['G', 'P'] and ":" in k:
-            continue
+    for who in who_group:
         # e.g. DRB4*01:03
         expression_alleles=[]
         expression_chars_found = set()
-        for an_allele in who_group[k]:
-            # if an allele in a who_group has an expression character but the group allele doesnt, 
-            # add it to shortnulls
-            if an_allele[-1] in expression_chars:
-                # e.g. DRB4*01:03:01:02N
-                exp_char = an_allele[-1]
-                if exp_char not in expression_chars_found:
-                    expression_chars_found.add(exp_char)
-                        
-                # e.g. DRB4*01:03N 
-                a_shortnull = k+exp_char
-                # add this allele to the set that this short null exapands to 
-                expression_alleles.append(an_allele) 
-        # only create a shortnull if there is one expression character in this who_group
-        # there is nothing to be done for who_groups that have both Q and L for example
-        if expression_alleles and expression_chars_found:
-            shortnulls[a_shortnull] = "/".join(expression_alleles)
+        if who[-1] not in expression_chars and who[-1] not in ['G', 'P'] and ":" in who:
+            for an_allele in who_group[who]:
+                # if an allele in a who_group has an expression character but the group allele doesnt, 
+                # add it to shortnulls
+                if an_allele[-1] in expression_chars:
+                    # e.g. DRB4*01:03:01:02N
+                    exp_char = an_allele[-1]
+                    if exp_char not in expression_chars_found:
+                        expression_chars_found.add(exp_char)
+                            
+                    # e.g. DRB4*01:03N 
+                    a_shortnull = who+exp_char
+                    # add this allele to the set that this short null exapands to 
+                    expression_alleles.append(an_allele) 
+            # only create a shortnull if there is one expression character in this who_group
+            # there is nothing to be done for who_groups that have both Q and L for example
+            if expression_alleles:
+                if len(expression_chars_found) ==1:
+                    shortnulls[a_shortnull] = "/".join(expression_alleles)
 
-    db.save_dict(db_connection, 'shortnulls', shortnulls,
-                 ('shortnull', 'allele_list'))
+    db.save_dict(db_connection, 'shortnulls', shortnulls, ('shortnull', 'allele_list'))
+    shortnulls = {k: v.split('/') for k, v in shortnulls.items()}
 
     return valid_alleles, who_alleles, xx_codes, who_group, shortnulls, exp_alleles
 

--- a/pyard/data_repository.py
+++ b/pyard/data_repository.py
@@ -334,15 +334,15 @@ def generate_alleles_and_xx_codes_and_who(db_connection: sqlite3.Connection, img
                 last_char = an_allele[-1]
                 if last_char in expression_chars:
                     # e.g. DRB4*01:03:01:02N
-                    expression_chars_found.add(exp_char)
-                    # e.g. DRB4*01:03N 
-                    a_shortnull = who+exp_char
+                    expression_chars_found.add(last_char)
                     # add this allele to the set that this short null exapands to 
                     expression_alleles.append(an_allele) 
             # only create a shortnull if there is one expression character in this who_group
             # there is nothing to be done for who_groups that have both Q and L for example
             if expression_alleles:
                 if len(expression_chars_found) ==1:
+                    # e.g. DRB4*01:03N 
+                    a_shortnull = who + list(expression_chars_found)[0]
                     shortnulls[a_shortnull] = "/".join(expression_alleles)
 
     db.save_dict(db_connection, 'shortnulls', shortnulls, ('shortnull', 'allele_list'))

--- a/pyard/data_repository.py
+++ b/pyard/data_repository.py
@@ -331,12 +331,10 @@ def generate_alleles_and_xx_codes_and_who(db_connection: sqlite3.Connection, img
             for an_allele in who_group[who]:
                 # if an allele in a who_group has an expression character but the group allele doesnt, 
                 # add it to shortnulls
-                if an_allele[-1] in expression_chars:
+                last_char = an_allele[-1]
+                if last_char in expression_chars:
                     # e.g. DRB4*01:03:01:02N
-                    exp_char = an_allele[-1]
-                    if exp_char not in expression_chars_found:
-                        expression_chars_found.add(exp_char)
-                            
+                    expression_chars_found.add(exp_char)
                     # e.g. DRB4*01:03N 
                     a_shortnull = who+exp_char
                     # add this allele to the set that this short null exapands to 

--- a/pyard/data_repository.py
+++ b/pyard/data_repository.py
@@ -324,26 +324,28 @@ def generate_alleles_and_xx_codes_and_who(db_connection: sqlite3.Connection, img
     # DRB5*01:08N | DRB5*01:08:01N/DRB5*01:08:02N 
     shortnulls = dict()
     for k in who_group:
+        if k[-1] not in expression_chars and k[-1] not in ['G', 'P'] and ":" in k:
+            continue
         # e.g. DRB4*01:03
-        ea=[]
-        expression_chars_found = dict()
-        for al in who_group[k]:
+        expression_alleles=[]
+        expression_chars_found = set()
+        for an_allele in who_group[k]:
             # if an allele in a who_group has an expression character but the group allele doesnt, 
             # add it to shortnulls
-            if al[-1] in expression_chars and k[-1] not in expression_chars and k[-1] not in ['G', 'P'] and ":" in k:
+            if an_allele[-1] in expression_chars:
                 # e.g. DRB4*01:03:01:02N
-                ex = al[-1]
-                if ex not in expression_chars_found:
-                    expression_chars_found[ex]=1
+                exp_char = an_allele[-1]
+                if exp_char not in expression_chars_found:
+                    expression_chars_found.add(exp_char)
                         
                 # e.g. DRB4*01:03N 
-                ek = k+ex
+                a_shortnull = k+exp_char
                 # add this allele to the set that this short null exapands to 
-                ea.append(al) 
+                expression_alleles.append(an_allele) 
         # only create a shortnull if there is one expression character in this who_group
         # there is nothing to be done for who_groups that have both Q and L for example
-        if ea and len(expression_chars_found.keys()) ==1:    
-            shortnulls[ek] = "/".join(ea)
+        if expression_alleles and expression_chars_found:
+            shortnulls[a_shortnull] = "/".join(expression_alleles)
 
     db.save_dict(db_connection, 'shortnulls', shortnulls,
                  ('shortnull', 'allele_list'))

--- a/pyard/pyard.py
+++ b/pyard/pyard.py
@@ -30,7 +30,7 @@ from . import db
 from . import data_repository as dr
 from .smart_sort import smart_sort_comparator
 from .exceptions import InvalidAlleleError, InvalidMACError, InvalidTypingError
-from .misc import get_n_field_allele
+from .misc import get_n_field_allele, get_2field_allele
 
 HLA_regex = re.compile("^HLA-")
 
@@ -47,7 +47,7 @@ default_config = {
     "reduce_P": True,
     "reduce_XX": True,
     "reduce_MAC": True,
-    "reduce_shortnull": False,
+    "reduce_shortnull": True,
     "map_drb345_to_drbx": True,
     "verbose_log": True
 }
@@ -319,8 +319,8 @@ class ARD(object):
             return self.redux_gl("/".join(self.shortnulls[glstring]), redux_type)
 
         # Handle exp_alleles
-        #if self.is_exp_allele(glstring):
-        #    return self.redux_gl("/".join(self.exp_alleles[glstring]), redux_type)
+        if self.is_exp_allele(glstring):
+            return self.redux_gl("/".join(self.exp_alleles[glstring]), redux_type)
 
         return self.redux(glstring, redux_type)
 
@@ -528,6 +528,11 @@ class ARD(object):
                 allele = allele[:-1]
                 if self._is_valid_allele(allele):
                     return True
+                else: 
+                    allele = get_2field_allele(allele)
+                    if self._is_valid_allele(allele):
+                        return True
+
             return self._is_valid_allele(allele)
         return True
 

--- a/pyard/pyard.py
+++ b/pyard/pyard.py
@@ -316,11 +316,11 @@ class ARD(object):
 
         # Handle shortnulls
         if self._config["reduce_shortnull"] and self.is_shortnull(glstring):
-            return self.redux_gl("/".join(self.shortnulls[glstring]), redux_type)
+            return self.redux_gl(self.shortnulls[glstring], redux_type)
 
         # Handle exp_alleles
         if self.is_exp_allele(glstring):
-            return self.redux_gl("/".join(self.exp_alleles[glstring]), redux_type)
+            return self.redux_gl(self.exp_alleles[glstring], redux_type)
 
         return self.redux(glstring, redux_type)
 

--- a/pyard/pyard.py
+++ b/pyard/pyard.py
@@ -316,11 +316,8 @@ class ARD(object):
 
         # Handle shortnulls
         if self._config["reduce_shortnull"] and self.is_shortnull(glstring):
-            return self.redux_gl(self.shortnulls[glstring], redux_type)
-
-        # Handle exp_alleles
-        if self.is_exp_allele(glstring):
-            return self.redux_gl(self.exp_alleles[glstring], redux_type)
+            return self.redux_gl("/".join(self.shortnulls[glstring]), redux_type)
+            #return self.redux_gl(self.shortnulls[glstring], redux_type)
 
         return self.redux(glstring, redux_type)
 
@@ -439,7 +436,7 @@ class ARD(object):
         else:
             alleles = [f'{locus_antigen}:{a}' for a in alleles]
 
-        return filter(self._is_valid_allele, alleles)
+        return list(filter(self._is_valid_allele, alleles))
 
     def _get_alleles_from_serology(self, serology) -> Iterable[str]:
         alleles = db.serology_to_alleles(self.db_connection, serology)
@@ -520,7 +517,6 @@ class ARD(object):
                 not self.is_XX(allele) and \
                 not self.is_serology(allele) and \
                 not self.is_v2(allele) and \
-                not self.is_exp_allele(allele) and \
                 not self.is_shortnull(allele):
             # Alleles ending with P or G are valid_alleles
             if allele.endswith(('P', 'G')):

--- a/pyard/pyard.py
+++ b/pyard/pyard.py
@@ -47,6 +47,7 @@ default_config = {
     "reduce_P": True,
     "reduce_XX": True,
     "reduce_MAC": True,
+    "reduce_shortnull": False,
     "map_drb345_to_drbx": True,
     "verbose_log": True
 }
@@ -100,7 +101,7 @@ class ARD(object):
         # Load ARS mappings
         self.ars_mappings = dr.generate_ars_mapping(self.db_connection, imgt_version)
         # Load Alleles and XX Codes
-        self.valid_alleles, self.who_alleles, self.xx_codes, self.who_group = \
+        self.valid_alleles, self.who_alleles, self.xx_codes, self.who_group, self.shortnulls, self.exp_alleles = \
             dr.generate_alleles_and_xx_codes_and_who(self.db_connection, imgt_version, self.ars_mappings)
 
         # Load Serology mappings
@@ -210,6 +211,8 @@ class ARD(object):
                 # If ambiguous, reduce to G group level
                 return self.redux(allele, 'lgx')
         else:
+            # TODO: make this an explicit lookup to the g_group or p_group table
+            # just having a shorter name be valid is not stringent enough
             if allele.endswith(('P', 'G')):
                 allele = allele[:-1]
             if self._is_valid_allele(allele):
@@ -311,6 +314,14 @@ class ARD(object):
             else:
                 raise InvalidMACError(f"{glstring} is an invalid MAC.")
 
+        # Handle shortnulls
+        if self._config["reduce_shortnull"] and self.is_shortnull(glstring):
+            return self.redux_gl("/".join(self.shortnulls[glstring]), redux_type)
+
+        # Handle exp_alleles
+        #if self.is_exp_allele(glstring):
+        #    return self.redux_gl("/".join(self.exp_alleles[glstring]), redux_type)
+
         return self.redux(glstring, redux_type)
 
     def is_XX(self, glstring: str, loc_antigen: str = None, code: str = None) -> bool:
@@ -392,6 +403,23 @@ class ARD(object):
         :return: bool to indicate if allele is valid
         """
         return allele in self.valid_alleles
+
+    def is_shortnull(self, allele):
+        """
+        Test if allele is valid in list of shortnull alleles and 
+        the reduce_shortnull is configured to True (WMDA rules)
+        :param allele: Allele to test
+        :return: bool to indicate if allele is valid
+        """
+        return allele in self.shortnulls and self._config["reduce_shortnull"]
+
+    def is_exp_allele(self, allele):
+        """
+        Test if allele is valid as a shortening (WHO rules)
+        :param allele: Allele to test
+        :return: bool to indicate if allele is valid
+        """
+        return allele in self.exp_alleles
 
     def _get_alleles(self, code, locus_antigen) -> Iterable[str]:
         """
@@ -491,16 +519,15 @@ class ARD(object):
         if not self.is_mac(allele) and \
                 not self.is_XX(allele) and \
                 not self.is_serology(allele) and \
-                not self.is_v2(allele):
+                not self.is_v2(allele) and \
+                not self.is_exp_allele(allele) and \
+                not self.is_shortnull(allele):
             # Alleles ending with P or G are valid_alleles
             if allele.endswith(('P', 'G')):
                 # remove the last character
                 allele = allele[:-1]
                 if self._is_valid_allele(allele):
                     return True
-                else:
-                    # reduce to 2 field for things like DPB1*28:01:01G
-                    allele = ':'.join(allele.split(':')[0:2])
             return self._is_valid_allele(allele)
         return True
 

--- a/tests/environment.py
+++ b/tests/environment.py
@@ -2,4 +2,4 @@ from pyard import ARD
 
 
 def before_all(context):
-    context.ard = ARD('3440', data_dir='/tmp/pyard')
+    context.ard = ARD('3440', data_dir='/tmp/py-ard')

--- a/tests/environment.py
+++ b/tests/environment.py
@@ -2,4 +2,4 @@ from pyard import ARD
 
 
 def before_all(context):
-    context.ard = ARD('3440', data_dir='/tmp/py-ard')
+    context.ard = ARD('3440', data_dir='/tmp/pyard')


### PR DESCRIPTION
implement shortnulls behavior with new config variable set to True by default.

This will address things like `DRB4*01:03N` and `DRB5*01:08N` both in terms of accepting them as valid and also by expanding them as appropriate to the list of longer alleles that have the same expression character.

`DRB5*01:08N`  is acceptable by WHO rules since all suballeles have N.
`DRB4*01:03N` is acceptable by WMDA (but not WHO) rules but this needs to be handled for things like HF analysis by expansion to something valid (vs rejection) to avoid bias
