### PR TITLE
Store IMGT DB Version Number

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ A*01:01/A*01:02
 $ pyard --gl 'DRB1*08:XX' -r G
 DRB1*08:01:01G/DRB1*08:02:01G/DRB1*08:03:02G/DRB1*08:04:01G/DRB1*08:05/ ...
 
-$ pyard -v 3290 --gl 'A1' -r lgx # For a particular version of DB
+$ pyard -i 3290 --gl 'A1' -r lgx # For a particular version of DB
 A*01:01/A*01:02/A*01:03/A*01:06/A*01:07/A*01:08/A*01:09/A*01:10/A*01:12/ ...
 ```
 ### Batch Reduce a CSV file

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -6,6 +6,8 @@ info:
 servers:
   - url: 'http://localhost:8080'
 tags:
+  - name: Database
+    description: IPD-IMGT/HLA DB Information
   - name: ARD Reduction
     description: Reduce GL String to ARD
   - name: MAC Expansion
@@ -13,6 +15,22 @@ tags:
   - name: DRBX Blender
     description: Blend DRBX based on DRB1 and DRB3/4/5
 paths:
+  /version:
+    get:
+      tags:
+        - Database
+      operationId: api.version_controller
+      summary: IPD-IMGT/HLA Version
+      description: |
+        Get IPD-IMGT/HLA DB Version used for this service
+      responses:
+        200:
+          description: IPD-IMGT/HLA version number
+          content:
+            application/json:
+              schema:
+                type: integer
+                example: 3440
   /redux:
     post:
       tags:

--- a/api.py
+++ b/api.py
@@ -79,3 +79,8 @@ def drbx_blender_controller():
             return {"DRBX_blend": blended_drbx}
         except DRBXBlenderError as e:
             return {"found": e.found, "expected": e.expected}
+
+
+def version_controller():
+    version = ard.get_db_version()
+    return {"version": version}, 200

--- a/pyard/data_repository.py
+++ b/pyard/data_repository.py
@@ -671,3 +671,40 @@ def generate_v2_to_v3_mapping(db_connection: sqlite3.Connection, imgt_version):
             dictionary=v2_to_v3_example,
             columns=("v2", "v3"),
         )
+
+
+def set_db_version(db_connection: sqlite3.Connection, imgt_version):
+    """
+    Set the IMGT database version number as a user_version string in
+    the database itself.
+
+    :param db_connection: Active SQLite Connection
+    :param imgt_version: current imgt_version
+    """
+    # If version already exists, don't reset
+    version = db.get_user_version(db_connection)
+    if version:
+        return version
+
+    version = imgt_version
+
+    if imgt_version == "Latest":
+        from urllib.request import urlopen
+
+        response = urlopen(
+            "https://raw.githubusercontent.com/ANHIG/IMGTHLA/Latest/release_version.txt"
+        )
+        for line in response:
+            l = line.decode("utf-8")
+            if l.find("version:") != -1:
+                # Version line looks like
+                # # version: IPD-IMGT/HLA 3.51.0
+                version = l.split()[-1].replace(".", "")
+
+    db.set_user_version(db_connection, int(version))
+    print("Version:", version)
+    return db.get_user_version(db_connection)
+
+
+def get_db_version(db_connection: sqlite3.Connection):
+    return db.get_user_version(db_connection)

--- a/pyard/db.py
+++ b/pyard/db.py
@@ -323,3 +323,36 @@ def similar_alleles(connection: sqlite3.Connection, allele_name: str) -> Set[str
     # Get out the first value of the tuple from the result list
     alleles = set(map(lambda t: t[0], result))
     return alleles
+
+
+def get_user_version(connection: sqlite3.Connection) -> int:
+    """
+    Retrieve user_version from db
+
+    :connection: sqlite3.Connection: SQLite DB Connection
+    """
+    query = "PRAGMA user_version"
+    cursor = connection.execute(query)
+    result = cursor.fetchone()
+    version = result[0]
+    cursor.close()
+
+    if version:
+        return version
+    return None
+
+
+def set_user_version(connection: sqlite3.Connection, version: int):
+    """
+    Save the version number as user_version in db
+
+    :connection: sqlite3.Connection:
+    :version: int: version number to store
+    @return:
+    """
+    query = f"PRAGMA user_version={version}"
+    cursor = connection.execute(query)
+    # commit transaction - writes to the db
+    connection.commit()
+    # close the cursor
+    cursor.close()

--- a/pyard/pyard.py
+++ b/pyard/pyard.py
@@ -121,6 +121,8 @@ class ARD(object):
         dr.generate_serology_mapping(self.db_connection, imgt_version)
         # Load V2 to V3 mappings
         dr.generate_v2_to_v3_mapping(self.db_connection, imgt_version)
+        # Save IMGT database version
+        dr.set_db_version(self.db_connection, imgt_version)
 
         # Close the current read-write db connection
         self.db_connection.close()
@@ -711,3 +713,10 @@ class ARD(object):
         :return: None
         """
         dr.generate_mac_codes(self.db_connection, True)
+
+    def get_db_version(self) -> str:
+        """
+        Get the IMGT DB Version Number
+        @return:
+        """
+        return dr.get_db_version(self.db_connection)

--- a/scripts/pyard
+++ b/scripts/pyard
@@ -22,6 +22,7 @@
 #    > http://www.opensource.org/licenses/lgpl-license.php
 #
 import argparse
+import sys
 
 import pyard
 
@@ -39,13 +40,29 @@ def get_imgt_version(imgt_version):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        usage="""[-v <IMGT DB Version>] [gl-string redux_type]""",
-        description="""py-ard tool to redux GL String""",
+        description="""
+        py-ard tool to redux GL String
+        """,
     )
-    parser.add_argument("-v", "--imgt-version", dest="imgt_version")
-    parser.add_argument("--gl", required=True, dest="gl_string")
     parser.add_argument(
-        "-r", choices=pyard.pyard.reduction_types, required=True, dest="redux_type"
+        "-v",
+        "--version",
+        dest="version",
+        action="store_true",
+        help="IPD-IMGT/HLA DB Version number",
+    )
+    parser.add_argument(
+        "-i",
+        "--imgt-version",
+        dest="imgt_version",
+        help="IPD-IMGT/HLA db to use for redux",
+    )
+    parser.add_argument("--gl", dest="gl_string", help="GL String to reduce")
+    parser.add_argument(
+        "-r",
+        choices=pyard.pyard.reduction_types,
+        dest="redux_type",
+        help="Reduction Method",
     )
 
     args = parser.parse_args()
@@ -55,6 +72,11 @@ if __name__ == "__main__":
         ard = pyard.ARD(imgt_version)
     else:
         ard = pyard.ARD()
+
+    if args.version:
+        version = ard.get_db_version()
+        print(f"IPD-IMGT/HLA version:", version)
+        sys.exit(0)
 
     print(ard.redux_gl(args.gl_string, args.redux_type))
     del ard

--- a/tests/test_pyard.py
+++ b/tests/test_pyard.py
@@ -38,6 +38,9 @@ from pyard.exceptions import InvalidAlleleError, InvalidMACError, InvalidTypingE
 
 
 class TestPyArd(unittest.TestCase):
+    db_version = None
+    ard = None
+
     @classmethod
     def setUpClass(cls) -> None:
         cls.db_version = "3440"
@@ -157,3 +160,6 @@ class TestPyArd(unittest.TestCase):
         allele_code = "C*02:ACMGS"
         allele_code_rx = self.ard.redux_gl(allele_code, "lgx")
         self.assertEqual(allele_code_rx, "C*02:02")
+
+    def test_imgt_db_version(self):
+        self.assertEqual(self.ard.get_db_version(), int(TestPyArd.db_version))


### PR DESCRIPTION
### Store IMGT DB Version Number in DB
 - save IMGT db version to db (eg, helps to know the IMGT version of Latest)
 - `/version` endpoint on the service
 - `pyard -v` shows the IMGT version in the database

Closes #132 