### PR TITLE
Fix xx_codes for broad/split

### DIFF
--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: ARD Reduction
   description: Reduce to ARD Level
-  version: "0.8.3"
+  version: "0.9.0"
 servers:
   - url: 'http://localhost:8080'
 tags:

--- a/pyard/__init__.py
+++ b/pyard/__init__.py
@@ -25,4 +25,4 @@ from .pyard import ARD
 from .blender import blender as dr_blender
 
 __author__ = """NMDP Bioinformatics"""
-__version__ = "0.8.3"
+__version__ = "0.9.0"

--- a/pyard/data_repository.py
+++ b/pyard/data_repository.py
@@ -20,6 +20,7 @@
 #    > http://www.fsf.org/licensing/licenses/lgpl.html
 #    > http://www.opensource.org/licenses/lgpl-license.php
 #
+import copy
 from collections import namedtuple
 import functools
 import sqlite3
@@ -380,7 +381,7 @@ def generate_alleles_and_xx_codes_and_who(
             if broad in xx_codes:
                 xx_codes[broad].extend(xx_codes[split])
             else:
-                xx_codes[broad] = xx_codes[split]
+                xx_codes[broad] = copy.deepcopy(xx_codes[split])
 
     # Save this version of the valid alleles
     db.save_set(db_connection, "alleles", valid_alleles, "allele")

--- a/pyard/pyard.py
+++ b/pyard/pyard.py
@@ -81,7 +81,6 @@ class ARD(object):
     def __init__(
         self, imgt_version: str = "Latest", data_dir: str = None, config: dict = None
     ):
-
         """
         ARD will load valid alleles, xx codes and MAC mappings for the given
         version of IMGT database, downloading and generating the database if

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.3
+current_version = 0.9.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ with open("requirements-tests.txt") as requirements_file:
 
 setup(
     name="py-ard",
-    version="0.8.3",
+    version="0.9.0",
     description="ARD reduction for HLA with Python",
     long_description=readme + "\n\n" + history,
     long_description_content_type="text/markdown",

--- a/tests/test_pyard.py
+++ b/tests/test_pyard.py
@@ -163,3 +163,9 @@ class TestPyArd(unittest.TestCase):
 
     def test_imgt_db_version(self):
         self.assertEqual(self.ard.get_db_version(), int(TestPyArd.db_version))
+
+    def test_xx_codes_broad_split(self):
+        self.assertFalse(
+            "DQB1*06" in self.ard.redux_gl("DQB1*05:XX", "lgx"),
+            "The split shouldn't include other splits",
+        )


### PR DESCRIPTION
Fix issue with Splits merged together. When creating broad for`DQB1*01`, `DQB1*05` was updated with `DQB1*06` expansion. 
Issue:Variables in Python are not values.

 - Create a copy of the list
 - Add test

Bumps version to 0.9.0

Fixes #191 