### PR TITLE
Special case 3130->3131 version of allelelist.txt

### DIFF
--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: ARD Reduction
   description: Reduce to ARD Level
-  version: "0.9.0"
+  version: "0.9.1"
 servers:
   - url: 'http://localhost:8080'
 tags:

--- a/pyard/__init__.py
+++ b/pyard/__init__.py
@@ -25,4 +25,4 @@ from .pyard import ARD
 from .blender import blender as dr_blender
 
 __author__ = """NMDP Bioinformatics"""
-__version__ = "0.9.0"
+__version__ = "0.9.1"

--- a/pyard/data_repository.py
+++ b/pyard/data_repository.py
@@ -343,7 +343,6 @@ def generate_alleles_and_xx_codes_and_who(
             f"{IMGT_HLA_URL}Latest/allelelist/Allelelist.{imgt_version}.txt"
         )
 
-    print("Using imgt_version:", imgt_version)
     try:
         allele_df = pd.read_csv(allele_list_url, header=6, usecols=["Allele"])
     except HTTPError as e:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.0
+current_version = 0.9.1
 commit = True
 tag = True
 
@@ -19,10 +19,4 @@ replace = version: "{new_version}"
 universal = 1
 
 [flake8]
-exclude =
-	venv,
-	.git,
-	__pycache__,
-	build,
-	dist,
-	docs
+exclude = venv, .git, __pycache__, build, dist, docs

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ with open("requirements-tests.txt") as requirements_file:
 
 setup(
     name="py-ard",
-    version="0.9.0",
+    version="0.9.1",
     description="ARD reduction for HLA with Python",
     long_description=readme + "\n\n" + history,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
- Special case 3130->3131 version of allelelist.txt. Discovered when importing 3130 in gfe-db
- Bump version to 0.9.1
```
$ pyard-import --db-version 3130
Importing IMGT database version: 3130
Using imgt_version: 3131
Version: 3130
Import complete for database version: 3130
```
Fix #193 
