### PR TITLE
Broads and Splits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
             -   id: check-yaml
             -   id: check-added-large-files
     -   repo: https://github.com/psf/black
-        rev: 22.3.0
+        rev: 23.1.0
         hooks:
             -   id: black
                 language_version: python3

--- a/README.md
+++ b/README.md
@@ -192,6 +192,16 @@ DRB1*08:01:01G/DRB1*08:02:01G/DRB1*08:03:02G/DRB1*08:04:01G/DRB1*08:05/ ...
 $ pyard -i 3290 --gl 'A1' -r lgx # For a particular version of DB
 A*01:01/A*01:02/A*01:03/A*01:06/A*01:07/A*01:08/A*01:09/A*01:10/A*01:12/ ...
 ```
+
+### Find Broad/Splits of an allele or serology typing
+```shell
+$ pyard --splits "A*10"
+A*10 = A*25/A*26/A*34/A*66
+
+$ pyard --splits B14
+B14 = B64/B65
+```
+
 ### Batch Reduce a CSV file
 
 `pyard-csv-reduce` can be used to batch process a CSV file with HLA typings. See [documentation](extras/README.md) for instructions on how to configure and run.

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: ARD Reduction
   description: Reduce to ARD Level
-  version: "0.9.0"
+  version: "0.9.1"
 servers:
   - url: 'http://localhost:8080'
 tags:

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -261,3 +261,52 @@ paths:
                     description: Describes what went wrong
                     type: string
                     example: "All of DRB1_SLUG, DRB3, DRB4, DRB5 values not provided"
+  /splits/{allele}:
+    get:
+      tags:
+        - Broad Splits
+      operationId: api.splits_controller
+      summary: Search Broad Split Mapping
+      description: |
+        Given a broad or a split, broad/split mappings will
+        be returned if available.
+      parameters:
+        - name: allele
+          in: path
+          description: A valid Allele/Serology
+          required: true
+          schema:
+            type: string
+          example: A*10
+      responses:
+        200:
+          description: Broad/Split mapping
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  broad:
+                    description: Broad Allele
+                    type: string
+                    example: "A*10"
+                  splits:
+                    description: Corresponding Splits
+                    type: array
+                    example:
+                      - "A*25"
+                      - "A*26"
+                      - "A*34"
+                      - "A*66"
+        404:
+          description: |
+            Broad/Split mapping not found for the given allele
+          content:
+            application/json:
+                schema:
+                  type: object
+                  properties:
+                    message:
+                      description: Mapping not found
+                      type: string
+                      example: "Broad/Split not found"

--- a/api.py
+++ b/api.py
@@ -84,3 +84,11 @@ def drbx_blender_controller():
 def version_controller():
     version = ard.get_db_version()
     return {"version": version}, 200
+
+
+def splits_controller(allele: str):
+    mapping = pyard.find_broad_splits(allele)
+    if mapping:
+        return {"broad": mapping[0], "splits": mapping[1]}, 200
+
+    return {"message": f"No Broad/Splits matched {allele}"}, 404

--- a/pyard/__init__.py
+++ b/pyard/__init__.py
@@ -25,4 +25,4 @@ from .pyard import ARD
 from .blender import blender as dr_blender
 
 __author__ = """NMDP Bioinformatics"""
-__version__ = "0.9.0"
+__version__ = "0.9.1"

--- a/pyard/__init__.py
+++ b/pyard/__init__.py
@@ -23,6 +23,7 @@
 #
 from .pyard import ARD
 from .blender import blender as dr_blender
+from .broad_splits import find_splits as find_broad_splits
 
 __author__ = """NMDP Bioinformatics"""
 __version__ = "0.9.1"

--- a/pyard/broad_splits.py
+++ b/pyard/broad_splits.py
@@ -46,36 +46,13 @@ broad_splits_dna_mapping = {
     "DRB1*06": ["DRB1*13", "DRB1*14"],
 }
 
-#
-# Derived from rel_ser_ser.txt
-# https://raw.githubusercontent.com/ANHIG/IMGTHLA/Latest/wmda/rel_ser_ser.txt
-#
-broad_splits_ser_mapping = {
-    "A9": ["A23", "A24"],
-    "A10": ["A25", "A26", "A34", "A66"],
-    "A19": ["A29", "A30", "A31", "A32", "A33", "A74"],
-    "A28": ["A68", "A69"],
-    "B5": ["B51", "B52"],
-    "B12": ["B44", "B45"],
-    "B15": ["B62", "B63", "B75", "B76", "B77"],
-    "B16": ["B38", "B39"],
-    "B17": ["B57", "B58"],
-    "B21": ["B49", "B50"],
-    "B22": ["B54", "B55", "B56"],
-    "B40": ["B60", "B61"],
-    "B70": ["B71", "B72"],
-    "Cw3": ["Cw9", "Cw10"],
-    "DQ1": ["DQ5", "DQ6"],
-    "DR2": ["DR15", "DR16"],
-    "DR3": ["DR17", "DR18"],
-    "DR5": ["DR11", "DR12"],
-    "DR6": ["DR13", "DR14"],
-}
+# Loaded at runtime
+broad_splits_ser_mapping = None
 
 HLA_regex = re.compile("^HLA-")
 
 
-def find_splits(allele: str) -> dict:
+def find_splits(allele: str) -> tuple:
     if HLA_regex.search(allele):
         prefix = True
         allele_name = allele.split("-")[1]
@@ -98,6 +75,6 @@ def find_splits(allele: str) -> dict:
 
 def _get_mapping(broad, mapping, prefix):
     if prefix:
-        return {broad: set(map(lambda x: "HLA-" + x, mapping[broad]))}
+        return "HLA-" + broad, list(map(lambda x: "HLA-" + x, mapping[broad]))
     else:
-        return {broad: mapping[broad]}
+        return broad, mapping[broad]

--- a/pyard/broad_splits.py
+++ b/pyard/broad_splits.py
@@ -20,6 +20,7 @@
 #    > http://www.fsf.org/licensing/licenses/lgpl.html
 #    > http://www.opensource.org/licenses/lgpl-license.php
 #
+import re
 
 #
 # Broad, Splits and Associated Antigens
@@ -44,6 +45,11 @@ broad_splits_dna_mapping = {
     "DRB1*02": ["DRB1*15", "DRB1*16"],
     "DRB1*06": ["DRB1*13", "DRB1*14"],
 }
+
+#
+# Derived from rel_ser_ser.txt
+# https://raw.githubusercontent.com/ANHIG/IMGTHLA/Latest/wmda/rel_ser_ser.txt
+#
 broad_splits_ser_mapping = {
     "A9": ["A23", "A24"],
     "A10": ["A25", "A26", "A34", "A66"],
@@ -65,3 +71,33 @@ broad_splits_ser_mapping = {
     "DR5": ["DR11", "DR12"],
     "DR6": ["DR13", "DR14"],
 }
+
+HLA_regex = re.compile("^HLA-")
+
+
+def find_splits(allele: str) -> dict:
+    if HLA_regex.search(allele):
+        prefix = True
+        allele_name = allele.split("-")[1]
+    else:
+        prefix = False
+        allele_name = allele
+
+    if "*" in allele_name:
+        mapping = broad_splits_dna_mapping
+    else:
+        mapping = broad_splits_ser_mapping
+
+    if allele_name in mapping:
+        return _get_mapping(allele_name, mapping, prefix)
+
+    for broad in mapping:
+        if allele_name in mapping[broad]:
+            return _get_mapping(broad, mapping, prefix)
+
+
+def _get_mapping(broad, mapping, prefix):
+    if prefix:
+        return {broad: set(map(lambda x: "HLA-" + x, mapping[broad]))}
+    else:
+        return {broad: mapping[broad]}

--- a/pyard/data_repository.py
+++ b/pyard/data_repository.py
@@ -344,7 +344,6 @@ def generate_alleles_and_xx_codes_and_who(
             f"{IMGT_HLA_URL}Latest/allelelist/Allelelist.{imgt_version}.txt"
         )
 
-    print("Using imgt_version:", imgt_version)
     try:
         allele_df = pd.read_csv(allele_list_url, header=6, usecols=["Allele"])
     except HTTPError as e:

--- a/pyard/data_repository.py
+++ b/pyard/data_repository.py
@@ -20,10 +20,13 @@
 #    > http://www.fsf.org/licensing/licenses/lgpl.html
 #    > http://www.opensource.org/licenses/lgpl-license.php
 #
+import sys
 import copy
 from collections import namedtuple
 import functools
 import sqlite3
+from urllib.error import HTTPError
+
 import pandas as pd
 
 from . import db
@@ -334,10 +337,22 @@ def generate_alleles_and_xx_codes_and_who(
     if imgt_version == "Latest":
         allele_list_url = f"{IMGT_HLA_URL}Latest/Allelelist.txt"
     else:
+        if imgt_version == "3130":
+            # 3130 was renamed to 3131 for Allelelist file only 🤷🏾‍
+            imgt_version = "3131"
         allele_list_url = (
             f"{IMGT_HLA_URL}Latest/allelelist/Allelelist.{imgt_version}.txt"
         )
-    allele_df = pd.read_csv(allele_list_url, header=6, usecols=["Allele"])
+
+    print("Using imgt_version:", imgt_version)
+    try:
+        allele_df = pd.read_csv(allele_list_url, header=6, usecols=["Allele"])
+    except HTTPError as e:
+        print(
+            f"Failed importing alleles for version {imgt_version} from {allele_list_url}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     # Create a set of valid alleles
     # All 2-field, 3-field and the original Alleles are considered valid alleles

--- a/pyard/load.py
+++ b/pyard/load.py
@@ -1,0 +1,34 @@
+from typing import Dict, List
+
+import pandas as pd
+
+IMGT_HLA_URL = "https://raw.githubusercontent.com/ANHIG/IMGTHLA/"
+
+
+def add_locus_name(locus: str, splits: str) -> List:
+    split_list = map(lambda sero: locus + sero, splits.split("/"))
+    return list(split_list)
+
+
+#
+# Derived from rel_ser_ser.txt
+# https://raw.githubusercontent.com/ANHIG/IMGTHLA/Latest/wmda/rel_ser_ser.txt
+#
+def load_serology_broad_split_mapping(imgt_version: str) -> Dict:
+    ser_ser_url = f"{IMGT_HLA_URL}{imgt_version}/wmda/rel_ser_ser.txt"
+    df_p = pd.read_csv(
+        ser_ser_url,
+        skiprows=6,
+        names=["Locus", "A", "Splits", "Associated"],
+        usecols=[0, 1, 2],
+        dtype="string",
+        sep=";",
+    ).dropna()
+
+    df_p["Sero"] = df_p["Locus"] + df_p["A"]
+    df_p["Splits"] = df_p[["Locus", "Splits"]].apply(
+        lambda x: add_locus_name(x["Locus"], x["Splits"]), axis=1
+    )
+
+    sero_mapping = df_p[["Sero", "Splits"]].set_index("Sero")["Splits"].to_dict()
+    return sero_mapping

--- a/pyard/pyard.py
+++ b/pyard/pyard.py
@@ -28,6 +28,7 @@ from typing import Iterable, Literal, List
 
 from . import db
 from . import data_repository as dr
+from . import broad_splits
 from .smart_sort import smart_sort_comparator
 from .exceptions import InvalidAlleleError, InvalidMACError, InvalidTypingError
 from .misc import get_n_field_allele, get_2field_allele, expression_chars
@@ -119,6 +120,9 @@ class ARD(object):
         self.shortnulls = dr.generate_short_nulls(self.db_connection, self.who_group)
 
         # Load Serology mappings
+        broad_splits.broad_splits_ser_mapping = (
+            dr.generate_serology_broad_split_mapping(self.db_connection, imgt_version)
+        )
         dr.generate_serology_mapping(self.db_connection, imgt_version)
         # Load V2 to V3 mappings
         dr.generate_v2_to_v3_mapping(self.db_connection, imgt_version)

--- a/scripts/pyard
+++ b/scripts/pyard
@@ -64,6 +64,7 @@ if __name__ == "__main__":
         dest="redux_type",
         help="Reduction Method",
     )
+    parser.add_argument("--splits", dest="splits", help="Find Broad and Splits")
 
     args = parser.parse_args()
 
@@ -76,6 +77,12 @@ if __name__ == "__main__":
     if args.version:
         version = ard.get_db_version()
         print(f"IPD-IMGT/HLA version:", version)
+        sys.exit(0)
+
+    if args.splits:
+        mapping = pyard.find_broad_splits(args.splits)
+        if mapping:
+            print(f"{mapping[0]} = {'/'.join(mapping[1])}")
         sys.exit(0)
 
     print(ard.redux_gl(args.gl_string, args.redux_type))

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.0
+current_version = 0.9.1
 commit = True
 tag = True
 
@@ -19,10 +19,4 @@ replace = version: "{new_version}"
 universal = 1
 
 [flake8]
-exclude =
-	venv,
-	.git,
-	__pycache__,
-	build,
-	dist,
-	docs
+exclude = venv, .git, __pycache__, build, dist, docs

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ with open("requirements-tests.txt") as requirements_file:
 
 setup(
     name="py-ard",
-    version="0.9.0",
+    version="0.9.1",
     description="ARD reduction for HLA with Python",
     long_description=readme + "\n\n" + history,
     long_description_content_type="text/markdown",

--- a/tests/features/broad_splits.feature
+++ b/tests/features/broad_splits.feature
@@ -1,0 +1,33 @@
+Feature: Broad Splits for DNA/Serology
+
+  Broad to Split mappings for serology is described here
+  https://hla.alleles.org/antigens/broads_splits.html
+
+  Scenario Outline: Broad allele and serology
+
+    Given the broad allele/serology is <Broad>
+    When it is expanded to the splits
+    Then the splits are <Splits>
+
+    Examples:
+      | Broad    | Splits            |
+      | A*09     | A*23/A*24         |
+      | HLA-B*05 | HLA-B*51/HLA-B*52 |
+      | DQB1*01  | DQB1*05/DQB1*06   |
+      | B5       | B51/B52           |
+      | B14      | B64/B65           |
+
+  Scenario Outline: Broad and Sibling Splits
+
+    Given the split allele/serology is <Split>
+    When split is searched in the mappings
+    Then the sibling splits are <Siblings>
+    And the corresponding broad is <Broad>
+
+    Examples:
+      | Split    | Siblings    | Broad    |
+      | A*23     | A*24        | A*09     |
+      | HLA-B*51 | HLA-B*52    | HLA-B*05 |
+      | DQB1*05  | DQB1*06     | DQB1*01  |
+      | B*55     | B*54/B*56   | B*22     |
+      | A25      | A26/A34/A66 | A10      |

--- a/tests/steps/broad_splits.py
+++ b/tests/steps/broad_splits.py
@@ -1,0 +1,45 @@
+from behave import *
+from hamcrest import assert_that, is_
+
+import pyard
+
+
+@given("the broad allele/serology is {broad}")
+def step_impl(context, broad):
+    context.broad = broad
+
+
+@when("it is expanded to the splits")
+def step_impl(context):
+    mapping = pyard.find_broad_splits(context.broad)
+    splits = mapping[1]
+    context.splits = "/".join(splits)
+
+
+@then("the splits are {splits}")
+def step_impl(context, splits):
+    assert_that(context.splits, is_(splits))
+
+
+@given("the split allele/serology is {split}")
+def step_impl(context, split):
+    context.split = split
+
+
+@when("split is searched in the mappings")
+def step_impl(context):
+    mapping = pyard.find_broad_splits(context.split)
+    context.broad = mapping[0]
+    splits = mapping[1]
+    splits.remove(context.split)
+    context.siblings = "/".join(splits)
+
+
+@then("the sibling splits are {siblings}")
+def step_impl(context, siblings):
+    assert_that(context.siblings, is_(siblings))
+
+
+@step("the corresponding broad is {broad}")
+def step_impl(context, broad):
+    assert_that(context.broad, is_(broad))


### PR DESCRIPTION
 - load serology mapping from `rel_ser_ser.txt` file and save to db
 - new `pyard.find_broad_splits` to search for broad/split mapping
 - `pyard --splits` gives the broad/split/sibling mapping #194, #195 
 -  Fix missing B14 #127 
 - `/splits` endpoint to search for broad/split mapping
 - Update README for `--splits` option

Fixes #127 
Fixes #194
Fixes #195 
