### PR TITLE
Change default cache directory + generate sample config

### DIFF
--- a/pyard/db.py
+++ b/pyard/db.py
@@ -22,13 +22,14 @@
 #
 import pathlib
 import sqlite3
+import tempfile
 from typing import Tuple, Dict, Set, List
 
 from pyard.misc import get_imgt_db_versions
 
 
-def get_pyard_db_install_directory():
-    return pathlib.Path.home() / ".pyard"
+def get_pyard_db_default_directory():
+    return pathlib.Path(tempfile.gettempdir()) / "pyard"
 
 
 def create_db_connection(data_dir, imgt_version, ro=False):
@@ -43,7 +44,7 @@ def create_db_connection(data_dir, imgt_version, ro=False):
     """
     # Set data directory where all the downloaded files will go
     if data_dir is None:
-        data_dir = get_pyard_db_install_directory()
+        data_dir = get_pyard_db_default_directory()
 
     db_filename = f"{data_dir}/pyard-{imgt_version}.sqlite3"
 
@@ -69,6 +70,9 @@ def create_db_connection(data_dir, imgt_version, ro=False):
     # Create the data directory if it doesn't exist
     if not pathlib.Path(data_dir).exists():
         pathlib.Path(data_dir).mkdir(parents=True, exist_ok=True)
+
+    if not pathlib.Path(db_filename).exists():
+        print(f"Creating {db_filename} as cache.")
 
     # Open the database for read/write
     file_uri = f"file:{db_filename}"

--- a/pyard/db.py
+++ b/pyard/db.py
@@ -20,6 +20,7 @@
 #    > http://www.fsf.org/licensing/licenses/lgpl.html
 #    > http://www.opensource.org/licenses/lgpl-license.php
 #
+import os
 import pathlib
 import sqlite3
 import tempfile
@@ -29,7 +30,14 @@ from pyard.misc import get_imgt_db_versions
 
 
 def get_pyard_db_default_directory():
-    return pathlib.Path(tempfile.gettempdir()) / "pyard"
+    """
+    The default directory is $TMPDIR/$USER-pyard
+    Check for `USERNAME` on Windows
+    @return: directory path to the default db directory
+    """
+    return pathlib.Path(tempfile.gettempdir()) / (
+        os.environ.get("USER", os.environ.get("USERNAME")) + "-pyard"
+    )
 
 
 def create_db_connection(data_dir, imgt_version, ro=False):

--- a/pyard/misc.py
+++ b/pyard/misc.py
@@ -85,6 +85,19 @@ def get_imgt_db_versions() -> List[str]:
         return versions
 
 
+def download_to_file(url: str, local_filename: str):
+    import urllib.request
+
+    req = urllib.request.Request(url)
+    res = urllib.request.urlopen(req, timeout=5)
+    if res.status == 200:
+        file_content = res.read().decode("utf-8")
+        with open(local_filename, "wt") as f:
+            f.write(file_content)
+    else:
+        print(f"Error downloading {url}")
+
+
 def get_data_dir(data_dir):
     if data_dir:
         path = pathlib.Path(data_dir)

--- a/pyard/misc.py
+++ b/pyard/misc.py
@@ -92,7 +92,7 @@ def get_data_dir(data_dir):
             raise RuntimeError(f"{data_dir} is not a valid directory")
         data_dir = path
     else:
-        data_dir = db.get_pyard_db_install_directory()
+        data_dir = db.get_pyard_db_default_directory()
     return data_dir
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 toml==0.10.2
-pandas>=1.1.4
+pandas==1.5.3

--- a/scripts/pyard-reduce-csv
+++ b/scripts/pyard-reduce-csv
@@ -38,7 +38,7 @@ import pandas as pd
 import pyard
 import pyard.drbx as drbx
 from pyard.exceptions import PyArdError
-from pyard.misc import get_data_dir, get_imgt_version
+from pyard.misc import get_data_dir, get_imgt_version, download_to_file
 
 
 def is_serology(allele: str) -> bool:
@@ -173,7 +173,7 @@ def create_drbx(row, locus_in_allele_name):
 if __name__ == "__main__":
     # config is specified with a -c parameter
     parser = argparse.ArgumentParser()
-    parser.add_argument("-c", "--config", help="JSON Configuration file", required=True)
+    parser.add_argument("-c", "--config", help="JSON Configuration file")
     parser.add_argument(
         "-d",
         "--data-dir",
@@ -194,8 +194,33 @@ if __name__ == "__main__":
         default=False,
         help="Don't print verbose log",
     )
+    parser.add_argument(
+        "-g",
+        "--generate-sample",
+        dest="generate",
+        action="store_true",
+        default=False,
+        help="Generate sample config file and csv file",
+    )
+
     args = parser.parse_args()
+
+    if args.generate:
+        config_url = "https://raw.githubusercontent.com/nmdp-bioinformatics/py-ard/master/extras/reduce_conf.json"
+        sample_config = "sample_reduce_conf.json"
+        download_to_file(config_url, sample_config)
+        print(f"Created {sample_config}")
+
+        sample_url = "https://raw.githubusercontent.com/nmdp-bioinformatics/py-ard/master/extras/sample.csv"
+        sample_csv = "sample.csv"
+        download_to_file(sample_url, sample_csv)
+        print(f"Created {sample_csv}")
+        sys.exit(0)
+
     config_filename = args.config
+    if not config_filename:
+        print("Config file required. Specify with -c/--config")
+        sys.exit(1)
 
     print("Using config file:", config_filename)
     with open(config_filename) as conf_file:


### PR DESCRIPTION
Change default cache directory
- Set `$TEMPDIR/pyard/` as the default path for storing db files. All commands have `--data-dir` option to use other directory.

Closes #198 
Closes #201 
Closes #202 

Add option to pyard-reduce-csv to generate sample config

- `--generate-sample` generates config/file

```
/tmp> pyard-reduce-csv --generate-sample
Created sample_reduce_conf.json
Created sample.csv
```
Closes #214 