### PR TITLE
P group redux

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ ard.redux('B14', 'lg')
 | Reduction Type | Description                                     |
 |----------------|-------------------------------------------------|
 | `G`            | Reduce to G Group Level                         |
+| `P`            | Reduce to P Group Level                         |
 | `lg`           | Reduce to 2 field ARD level (append `g`)        |
 | `lgx`          | Reduce to 2 field ARD level                     |
 | `W`            | Reduce/Expand to 3 field WHO nomenclature level |

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: ARD Reduction
   description: Reduce to ARD Level
-  version: "1.0.0rc1"
+  version: "1.0.0rc2"
 servers:
   - url: 'http://localhost:8080'
 tags:

--- a/pyard/__init__.py
+++ b/pyard/__init__.py
@@ -27,7 +27,7 @@ from .constants import DEFAULT_CACHE_SIZE
 from .misc import get_imgt_db_versions as db_versions
 
 __author__ = """NMDP Bioinformatics"""
-__version__ = "1.0.0rc1"
+__version__ = "1.0.0rc2"
 
 
 def init(

--- a/pyard/__init__.py
+++ b/pyard/__init__.py
@@ -23,7 +23,7 @@
 #
 from .blender import blender as dr_blender
 from .broad_splits import find_splits as find_broad_splits
-from .misc import DEFAULT_CACHE_SIZE
+from .constants import DEFAULT_CACHE_SIZE
 from .misc import get_imgt_db_versions as db_versions
 
 __author__ = """NMDP Bioinformatics"""

--- a/pyard/__init__.py
+++ b/pyard/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from functools import lru_cache
 
 #
 #    pyard pyARD.
@@ -24,8 +23,8 @@ from functools import lru_cache
 #
 from .blender import blender as dr_blender
 from .broad_splits import find_splits as find_broad_splits
-from .misc import get_imgt_db_versions as db_versions
 from .misc import DEFAULT_CACHE_SIZE
+from .misc import get_imgt_db_versions as db_versions
 
 __author__ = """NMDP Bioinformatics"""
 __version__ = "1.0.0rc1"

--- a/pyard/ard.py
+++ b/pyard/ard.py
@@ -33,11 +33,13 @@ from .exceptions import InvalidAlleleError, InvalidMACError, InvalidTypingError
 from .misc import (
     get_n_field_allele,
     get_2field_allele,
-    expression_chars,
-    DEFAULT_CACHE_SIZE,
+    validate_reduction_type,
+)
+from .constants import (
     HLA_regex,
     VALID_REDUCTION_TYPES,
-    validate_reduction_type,
+    expression_chars,
+    DEFAULT_CACHE_SIZE,
 )
 from .smart_sort import smart_sort_comparator
 

--- a/pyard/ard.py
+++ b/pyard/ard.py
@@ -22,14 +22,13 @@
 #    > http://www.opensource.org/licenses/lgpl-license.php
 #
 import functools
-import sys
 import re
+import sys
 from typing import Iterable, List
 
-from . import db
-from . import data_repository as dr
 from . import broad_splits
-from .smart_sort import smart_sort_comparator
+from . import data_repository as dr
+from . import db
 from .exceptions import InvalidAlleleError, InvalidMACError, InvalidTypingError
 from .misc import (
     get_n_field_allele,
@@ -40,6 +39,7 @@ from .misc import (
     VALID_REDUCTION_TYPES,
     validate_reduction_type,
 )
+from .smart_sort import smart_sort_comparator
 
 default_config = {
     "reduce_serology": True,
@@ -90,9 +90,7 @@ class ARD(object):
         self.db_connection, _ = db.create_db_connection(data_dir, imgt_version)
 
         # Load ARS mappings
-        self.ars_mappings, p_group = dr.generate_ars_mapping(
-            self.db_connection, imgt_version
-        )
+        self.ars_mappings = dr.generate_ars_mapping(self.db_connection, imgt_version)
         # Load Alleles and XX Codes
         (
             self.valid_alleles,
@@ -101,7 +99,7 @@ class ARD(object):
             self.who_group,
             self.exp_alleles,
         ) = dr.generate_alleles_and_xx_codes_and_who(
-            self.db_connection, imgt_version, self.ars_mappings, p_group
+            self.db_connection, imgt_version, self.ars_mappings
         )
 
         # Generate short nulls from WHO mapping
@@ -194,6 +192,8 @@ class ARD(object):
                 return self.ars_mappings.dup_g[allele]
             else:
                 return self.ars_mappings.g_group[allele]
+        elif redux_type == "P" and allele in self.ars_mappings.p_group:
+            return self.ars_mappings.p_group[allele]
         elif redux_type in ["lgx", "lg"]:
             if allele in self.ars_mappings.dup_lgx:
                 redux_allele = self.ars_mappings.dup_lgx[allele]

--- a/pyard/constants.py
+++ b/pyard/constants.py
@@ -1,0 +1,10 @@
+import re
+
+DEFAULT_CACHE_SIZE = 1_000
+
+HLA_regex = re.compile("^HLA-")
+
+VALID_REDUCTION_TYPES = ["G", "P", "lg", "lgx", "W", "exon", "U2"]
+expression_chars = ["N", "Q", "L", "S"]
+# List of P and G characters
+PandG_chars = ["P", "G"]

--- a/pyard/data_repository.py
+++ b/pyard/data_repository.py
@@ -23,7 +23,6 @@
 import copy
 import functools
 import sqlite3
-from collections import namedtuple
 
 import pandas as pd
 
@@ -37,31 +36,14 @@ from .load import (
     load_serology_mappings,
     load_latest_version,
 )
-from .misc import expression_chars
+from .constants import expression_chars
+from .mappings import ars_mapping_tables, ARSMapping, code_mapping_tables
 from .misc import (
     get_2field_allele,
     get_3field_allele,
     number_of_fields,
     get_1field_allele,
 )
-
-ars_mapping_tables = [
-    "dup_g",
-    "dup_lgx",
-    "g_group",
-    "p_group",
-    "lgx_group",
-    "exon_group",
-    "p_not_g",
-]
-ARSMapping = namedtuple("ARSMapping", ars_mapping_tables)
-
-code_mapping_tables = [
-    "alleles",
-    "xx_codes",
-    "who_alleles",
-    "who_group",
-]
 
 
 def expression_reduce(df):

--- a/pyard/data_repository.py
+++ b/pyard/data_repository.py
@@ -49,6 +49,7 @@ ars_mapping_tables = [
     "dup_g",
     "dup_lgx",
     "g_group",
+    "p_group",
     "lgx_group",
     "exon_group",
     "p_not_g",
@@ -162,14 +163,22 @@ def generate_ars_mapping(db_connection: sqlite3.Connection, imgt_version):
     )
     exon_group = df_exon.set_index("A")["exon"].to_dict()
 
-    # save
-    return db.save_ars_mappings(
-        db_connection, dup_g, dup_lgx, exon_group, g_group, lgx_group, p_group, p_not_g
+    ars_mapping = ARSMapping(
+        dup_g=dup_g,
+        dup_lgx=dup_lgx,
+        g_group=g_group,
+        p_group=p_group,
+        lgx_group=lgx_group,
+        exon_group=exon_group,
+        p_not_g=p_not_g,
     )
+    db.save_ars_mappings(db_connection, ars_mapping)
+
+    return ars_mapping
 
 
 def generate_alleles_and_xx_codes_and_who(
-    db_connection: sqlite3.Connection, imgt_version, ars_mappings, p_group
+    db_connection: sqlite3.Connection, imgt_version, ars_mappings
 ):
     if db.tables_exist(db_connection, code_mapping_tables):
         return db.load_code_mappings(db_connection)
@@ -232,7 +241,7 @@ def generate_alleles_and_xx_codes_and_who(
             allele_df[["Allele", "2d"]].rename(columns={"2d": "nd"}),
             allele_df[["Allele", "3d"]].rename(columns={"3d": "nd"}),
             pd.DataFrame(ars_mappings.g_group.items(), columns=["Allele", "nd"]),
-            pd.DataFrame(p_group.items(), columns=["Allele", "nd"]),
+            pd.DataFrame(ars_mappings.p_group.items(), columns=["Allele", "nd"]),
         ],
         ignore_index=True,
     )

--- a/pyard/db.py
+++ b/pyard/db.py
@@ -374,6 +374,7 @@ def load_ars_mappings(db_connection):
         db_connection, table_name="dup_lgx", columns=("allele", "lgx_group")
     )
     g_group = load_dict(db_connection, table_name="g_group", columns=("allele", "g"))
+    p_group = load_dict(db_connection, table_name="p_group", columns=("allele", "p"))
     lgx_group = load_dict(
         db_connection, table_name="lgx_group", columns=("allele", "lgx")
     )
@@ -381,65 +382,59 @@ def load_ars_mappings(db_connection):
         db_connection, table_name="exon_group", columns=("allele", "exon")
     )
     p_not_g = load_dict(db_connection, table_name="p_not_g", columns=("allele", "lgx"))
-    return (
-        ARSMapping(
-            dup_g=dup_g,
-            dup_lgx=dup_lgx,
-            g_group=g_group,
-            lgx_group=lgx_group,
-            exon_group=exon_group,
-            p_not_g=p_not_g,
-        ),
-        None,
+    return ARSMapping(
+        dup_g=dup_g,
+        dup_lgx=dup_lgx,
+        g_group=g_group,
+        p_group=p_group,
+        lgx_group=lgx_group,
+        exon_group=exon_group,
+        p_not_g=p_not_g,
     )
 
 
-def save_ars_mappings(
-    db_connection, dup_g, dup_lgx, exon_group, g_group, lgx_group, p_group, p_not_g
-):
+def save_ars_mappings(db_connection: sqlite3.Connection, ars_mapping: ARSMapping):
     save_dict(
         db_connection,
         table_name="p_not_g",
-        dictionary=p_not_g,
+        dictionary=ars_mapping.p_not_g,
         columns=("allele", "lgx"),
     )
     save_dict(
         db_connection,
         table_name="dup_g",
-        dictionary=dup_g,
+        dictionary=ars_mapping.dup_g,
         columns=("allele", "g_group"),
     )
     save_dict(
         db_connection,
         table_name="dup_lgx",
-        dictionary=dup_lgx,
+        dictionary=ars_mapping.dup_lgx,
         columns=("allele", "lgx_group"),
     )
     save_dict(
-        db_connection, table_name="g_group", dictionary=g_group, columns=("allele", "g")
+        db_connection,
+        table_name="g_group",
+        dictionary=ars_mapping.g_group,
+        columns=("allele", "g"),
+    )
+    save_dict(
+        db_connection,
+        table_name="p_group",
+        dictionary=ars_mapping.p_group,
+        columns=("allele", "p"),
     )
     save_dict(
         db_connection,
         table_name="lgx_group",
-        dictionary=lgx_group,
+        dictionary=ars_mapping.lgx_group,
         columns=("allele", "lgx"),
     )
     save_dict(
         db_connection,
         table_name="exon_group",
-        dictionary=exon_group,
+        dictionary=ars_mapping.exon_group,
         columns=("allele", "exon"),
-    )
-    return (
-        ARSMapping(
-            dup_g=dup_g,
-            dup_lgx=dup_lgx,
-            g_group=g_group,
-            lgx_group=lgx_group,
-            exon_group=exon_group,
-            p_not_g=p_not_g,
-        ),
-        p_group,
     )
 
 

--- a/pyard/db.py
+++ b/pyard/db.py
@@ -24,7 +24,7 @@ import pathlib
 import sqlite3
 from typing import Tuple, Dict, Set, List
 
-from .data_repository import ARSMapping
+from .mappings import ARSMapping
 from .misc import get_imgt_db_versions, get_default_db_directory
 
 

--- a/pyard/exceptions.py
+++ b/pyard/exceptions.py
@@ -25,6 +25,7 @@ class InvalidMACError(PyArdError):
 
 class InvalidTypingError(PyArdError):
     def __init__(self, message: str, cause=None) -> None:
+        super().__init__(message)
         self.cause = cause
 
     def __str__(self) -> str:

--- a/pyard/mappings.py
+++ b/pyard/mappings.py
@@ -1,0 +1,20 @@
+from collections import namedtuple
+
+ars_mapping_tables = [
+    "dup_g",
+    "dup_lgx",
+    "g_group",
+    "p_group",
+    "lgx_group",
+    "exon_group",
+    "p_not_g",
+]
+code_mapping_tables = [
+    "alleles",
+    "exp_alleles",
+    "xx_codes",
+    "who_alleles",
+    "who_group",
+]
+
+ARSMapping = namedtuple("ARSMapping", ars_mapping_tables)

--- a/pyard/misc.py
+++ b/pyard/misc.py
@@ -2,11 +2,11 @@
 import pathlib
 import re
 import tempfile
-from typing import List, Literal
+from typing import List
 
 HLA_regex = re.compile("^HLA-")
 
-VALID_REDUCTION_TYPES = ["G", "lg", "lgx", "W", "exon", "U2"]
+VALID_REDUCTION_TYPES = ["G", "P", "lg", "lgx", "W", "exon", "U2"]
 expression_chars = ["N", "Q", "L", "S"]
 # List of P and G characters
 PandG_chars = ["P", "G"]

--- a/pyard/misc.py
+++ b/pyard/misc.py
@@ -1,17 +1,9 @@
 # List of expression characters
 import pathlib
-import re
 import tempfile
 from typing import List
 
-HLA_regex = re.compile("^HLA-")
-
-VALID_REDUCTION_TYPES = ["G", "P", "lg", "lgx", "W", "exon", "U2"]
-expression_chars = ["N", "Q", "L", "S"]
-# List of P and G characters
-PandG_chars = ["P", "G"]
-
-DEFAULT_CACHE_SIZE = 1_000
+from pyard.constants import VALID_REDUCTION_TYPES, expression_chars, PandG_chars
 
 
 def get_n_field_allele(allele: str, n: int, preserve_expression=False) -> str:

--- a/pyard/smart_sort.py
+++ b/pyard/smart_sort.py
@@ -24,7 +24,7 @@
 import functools
 import re
 
-expr_regex = re.compile("[NQLSGg]")
+expr_regex = re.compile("[PNQLSGg]")
 glstring_chars = re.compile("[/|+^~]")
 
 

--- a/scripts/pyard
+++ b/scripts/pyard
@@ -66,12 +66,6 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    if args.splits:
-        mapping = pyard.find_broad_splits(args.splits)
-        if mapping:
-            print(f"{mapping[0]} = {'/'.join(mapping[1])}")
-        sys.exit(0)
-
     imgt_version = get_imgt_version(args.imgt_version)
     data_dir = get_data_dir(args.data_dir)
     ard = pyard.init(imgt_version=imgt_version, data_dir=data_dir)
@@ -80,6 +74,12 @@ if __name__ == "__main__":
         version = ard.get_db_version()
         print(f"IPD-IMGT/HLA version:", version)
         print(f"py-ard version:", pyard.__version__)
+        sys.exit(0)
+
+    if args.splits:
+        mapping = pyard.find_broad_splits(args.splits)
+        if mapping:
+            print(f"{mapping[0]} = {'/'.join(mapping[1])}")
         sys.exit(0)
 
     try:

--- a/scripts/pyard
+++ b/scripts/pyard
@@ -24,6 +24,7 @@
 import argparse
 import sys
 
+from pyard.constants import VALID_REDUCTION_TYPES
 import pyard.misc
 from pyard.exceptions import InvalidAlleleError
 from pyard.misc import get_data_dir, get_imgt_version
@@ -57,7 +58,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "-r",
         "--redux-type",
-        choices=pyard.misc.VALID_REDUCTION_TYPES,
+        choices=VALID_REDUCTION_TYPES,
         dest="redux_type",
         help="Reduction Method",
     )
@@ -85,11 +86,12 @@ if __name__ == "__main__":
         if args.redux_type:
             print(ard.redux(args.gl_string, args.redux_type))
         else:
-            for redux_type in pyard.misc.VALID_REDUCTION_TYPES:
+            for redux_type in VALID_REDUCTION_TYPES:
                 redux_type_info = f"Reduction Method: {redux_type}"
                 print(redux_type_info)
                 print("-" * len(redux_type_info))
                 print(ard.redux(args.gl_string, redux_type))
+                print()
     except InvalidAlleleError as e:
         print("Error:", e)
 

--- a/scripts/pyard
+++ b/scripts/pyard
@@ -53,9 +53,10 @@ if __name__ == "__main__":
         dest="imgt_version",
         help="IPD-IMGT/HLA db to use for redux",
     )
-    parser.add_argument("--gl", dest="gl_string", help="GL String to reduce")
+    parser.add_argument("-g", "--gl", dest="gl_string", help="GL String to reduce")
     parser.add_argument(
         "-r",
+        "--redux-type",
         choices=pyard.misc.VALID_REDUCTION_TYPES,
         dest="redux_type",
         help="Reduction Method",

--- a/scripts/pyard-status
+++ b/scripts/pyard-status
@@ -26,6 +26,7 @@ import os
 import re
 
 import pyard
+import pyard.mappings
 from pyard import db, data_repository
 from pyard.misc import get_data_dir
 
@@ -93,8 +94,8 @@ if __name__ == "__main__":
             print(f"|{'Table Name':20}|{'Rows':20}|")
             print(f"|{'-' * 41}|")
             for table in (
-                data_repository.ars_mapping_tables
-                + data_repository.code_mapping_tables
+                pyard.mappings.ars_mapping_tables
+                + pyard.mappings.code_mapping_tables
                 + ["mac_codes"]
             ):
                 if db.table_exists(db_connection, table):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0rc1
+current_version = 1.0.0rc2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ with open("requirements-tests.txt") as requirements_file:
 
 setup(
     name="py-ard",
-    version="1.0.0rc1",
+    version="1.0.0rc2",
     description="ARD reduction for HLA with Python",
     long_description=readme + "\n\n" + history,
     long_description_content_type="text/markdown",

--- a/tests/features/p_group.feature
+++ b/tests/features/p_group.feature
@@ -1,0 +1,12 @@
+Feature: P Groups
+
+  Scenario Outline:
+
+    Given the allele as <Allele>
+    When reducing on the <Level> level (ambiguous)
+    Then the reduced allele is found to be <Redux Allele>
+
+    Examples:
+      | Allele        | Level | Redux Allele |
+      | B*44:15:01:01 | P     | B*44:15P     |
+      | A*02:01:01    | P     | A*02:01:01   |

--- a/tests/test_pyard.py
+++ b/tests/test_pyard.py
@@ -33,6 +33,7 @@ import os
 import unittest
 
 import pyard
+from pyard.constants import DEFAULT_CACHE_SIZE
 from pyard.exceptions import InvalidAlleleError, InvalidMACError, InvalidTypingError
 from pyard.misc import validate_reduction_type
 
@@ -170,11 +171,9 @@ class TestPyArd(unittest.TestCase):
     def test_cache_info(self):
         # validate the default cache size
         self.assertEqual(
-            self.ard._redux_allele.cache_info().maxsize, pyard.misc.DEFAULT_CACHE_SIZE
+            self.ard._redux_allele.cache_info().maxsize, DEFAULT_CACHE_SIZE
         )
-        self.assertEqual(
-            self.ard.redux.cache_info().maxsize, pyard.misc.DEFAULT_CACHE_SIZE
-        )
+        self.assertEqual(self.ard.redux.cache_info().maxsize, DEFAULT_CACHE_SIZE)
         # validate you can change the cache size
         higher_cache_size = 5_000_000
         another_ard = pyard.init(


### PR DESCRIPTION
Able to move this to 1.0 release

- Add reduction type of `P` for P-group reduction. Currently handles alleles only from [p_group mapping](https://hla.alleles.org/alleles/p_groups.html)

```
pyard --gl 'A*02:01:01:03' -r "P"
A*02:01P
```

Fixes #200 

cc @lgragert 

Also fix for `AttributeError: 'InvalidTypingError' object has no attribute 'message'`
