### PR TITLE
Missing requirements.txt in distribution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL MAINTAINER="Pradeep Bashyal"
 
 WORKDIR /app
 
-ARG PY_ARD_VERSION=1.0.0rc6
+ARG PY_ARD_VERSION=1.0.0rc7
 
 COPY requirements.txt /app
 RUN pip install --no-cache-dir --upgrade pip && \

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,7 @@ include AUTHORS.rst
 include CONTRIBUTING.rst
 include HISTORY.rst
 include LICENSE
-include README.rst
+include README.md
 include pyard/*.csv
 include requirements.txt
 include requirements-tests.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,8 @@ include HISTORY.rst
 include LICENSE
 include README.rst
 include pyard/*.csv
+include requirements.txt
+include requirements-tests.txt
 
 recursive-exclude tests *
 recursive-exclude * __pycache__

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Human leukocyte antigen (HLA) genes encode cell surface proteins that are import
 ```shell
 pip install py-ard
 ```
+Note: With `py-ard` version *1.0.0* and higher, the redux API has changed. If your use requires the older API, please install with `pip install py-ard==0.9.2`
+
 
 ### Install With Homebrew
 

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: ARD Reduction
   description: Reduce to ARD Level
-  version: "1.0.0rc6"
+  version: "1.0.0rc7"
 servers:
   - url: 'http://localhost:8080'
 tags:

--- a/pyard/__init__.py
+++ b/pyard/__init__.py
@@ -27,7 +27,7 @@ from .constants import DEFAULT_CACHE_SIZE
 from .misc import get_imgt_db_versions as db_versions
 
 __author__ = """NMDP Bioinformatics"""
-__version__ = "1.0.0rc6"
+__version__ = "1.0.0rc7"
 
 
 def init(

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0rc6
+current_version = 1.0.0rc7
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ with open("requirements-tests.txt") as requirements_file:
 
 setup(
     name="py-ard",
-    version="1.0.0rc6",
+    version="1.0.0rc7",
     description="ARD reduction for HLA with Python",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Was failing to setup.py install from PyPi. Added missing ` requirements.txt` files

Fixes #227 