### PR TITLE
Fix 2 and 3 field P group redux

### DIFF
--- a/pyard/data_repository.py
+++ b/pyard/data_repository.py
@@ -79,9 +79,6 @@ def generate_ard_mapping(db_connection: sqlite3.Connection, imgt_version) -> ARS
     df_g_group = load_g_group(imgt_version)
     df_p_group = load_p_group(imgt_version)
 
-    # Extract p group mapping
-    p_group = df_p_group.set_index("A")["P"].to_dict()
-
     # compare df_p_group["2d"] with df_g_group["2d"] to find 2-field alleles in the
     # P-group that aren't in the G-group
     p_not_in_g = set(df_p_group["2d"]) - set(df_g_group["2d"])
@@ -124,7 +121,7 @@ def generate_ard_mapping(db_connection: sqlite3.Connection, imgt_version) -> ARS
         .to_dict()["lgx"]
     )
 
-    # Creating dictionaries with mac_code->ARD group mapping
+    # Extract G group mapping
     df_g = pd.concat(
         [
             df_g_group[["2d", "G"]].rename(columns={"2d": "A"}),
@@ -135,6 +132,18 @@ def generate_ard_mapping(db_connection: sqlite3.Connection, imgt_version) -> ARS
     )
     g_group = df_g.set_index("A")["G"].to_dict()
 
+    # Extract P group mapping
+    df_p = pd.concat(
+        [
+            df_p_group[["2d", "P"]].rename(columns={"2d": "A"}),
+            df_p_group[["3d", "P"]].rename(columns={"3d": "A"}),
+            df_p_group[["A", "P"]],
+        ],
+        ignore_index=True,
+    )
+    p_group = df_p.set_index("A")["P"].to_dict()
+
+    # Extract lgx group mapping
     df_lgx = pd.concat(
         [
             df_g_group[["2d", "lgx"]].rename(columns={"2d": "A"}),
@@ -144,7 +153,7 @@ def generate_ard_mapping(db_connection: sqlite3.Connection, imgt_version) -> ARS
     )
     lgx_group = df_lgx.set_index("A")["lgx"].to_dict()
 
-    # exon
+    # Extract exon mapping
     df_exon = pd.concat(
         [
             df_g_group[["A", "3d"]].rename(columns={"3d": "exon"}),

--- a/pyard/db.py
+++ b/pyard/db.py
@@ -58,7 +58,7 @@ def create_db_connection(data_dir, imgt_version, ro=False):
     if imgt_version != "Latest":
         if not pathlib.Path(db_filename).exists():
             all_imgt_versions = get_imgt_db_versions()
-            if imgt_version not in all_imgt_versions:
+            if str(imgt_version) not in all_imgt_versions:
                 raise ValueError(
                     f"{imgt_version} is not a valid IMGT database version."
                 )

--- a/pyard/load.py
+++ b/pyard/load.py
@@ -110,7 +110,8 @@ def load_p_group(imgt_version):
         sys.exit(1)
 
     # the P-group is named for its first allele
-    df_p["P"] = df_p["A"].apply(get_P_name)
+    # The P column is already present in the file
+    # df_p["P"] = df_p["A"].apply(get_P_name)
     # convert slash delimited string to a list
     df_p["A"] = df_p["A"].apply(lambda a: a.split("/"))
     df_p = df_p.explode("A")
@@ -121,6 +122,7 @@ def load_p_group(imgt_version):
     # C* 06:06:01:02 06:06P
     # C* 06:271 06:06P
     df_p["2d"] = df_p["A"].apply(get_2field_allele)
+    df_p["3d"] = df_p["A"].apply(get_3field_allele)
     # lgx has the P-group name without the P for comparison
     df_p["lgx"] = df_p["P"].apply(get_2field_allele)
     return df_p

--- a/tests/features/p_group.feature
+++ b/tests/features/p_group.feature
@@ -9,4 +9,8 @@ Feature: P Groups
     Examples:
       | Allele        | Level | Redux Allele |
       | B*44:15:01:01 | P     | B*44:15P     |
-      | A*02:01:01    | P     | A*02:01:01   |
+      | A*02:01:01    | P     | A*02:01P     |
+      | B*07:02       | P     | B*07:02P     |
+      | B*07:02:01    | P     | B*07:02P     |
+      | B*07:02:01:01 | P     | B*07:02P     |
+      | B*15:14       | P     | B*15:14P     |


### PR DESCRIPTION
Fixes #230 

Reduction of 2 and 3 field alleles weren't being found in the mapping table.

  - Add 2 and 3 field columns to the mapping table.
  - Add more examples to p group feature file