### PR TITLE
Allow ARS suffix instead of g

### DIFF
--- a/pyard/ard.py
+++ b/pyard/ard.py
@@ -215,6 +215,7 @@ class ARD(object):
                 # return allele with only first 2 field
                 redux_allele = ":".join(allele.split(":")[0:2])
             if redux_type == "lg":
+                # ARS suffix maybe used instead of g
                 if self._config["ARS_as_lg"]:
                     return redux_allele + "ARS"
                 # lg mode has g appended with lgx reduction

--- a/pyard/ard.py
+++ b/pyard/ard.py
@@ -54,6 +54,7 @@ default_config = {
     "ping": False,
     "map_drb345_to_drbx": True,
     "verbose_log": True,
+    "ARS_as_lg": False,
 }
 
 
@@ -64,7 +65,7 @@ class ARD(object):
     """
     ARD reduction for HLA
     Allows reducing alleles, allele code(MAC), Serology to
-    G, lg, lgx, W, exon and U2 levels.
+    G, lg, lgx, W, exon, S and U2 levels.
     """
 
     def __init__(
@@ -214,6 +215,8 @@ class ARD(object):
                 # return allele with only first 2 field
                 redux_allele = ":".join(allele.split(":")[0:2])
             if redux_type == "lg":
+                if self._config["ARS_as_lg"]:
+                    return redux_allele + "ARS"
                 # lg mode has g appended with lgx reduction
                 return redux_allele + "g"
             return redux_allele

--- a/tests/environment.py
+++ b/tests/environment.py
@@ -26,7 +26,13 @@ def before_all(context):
     context.ard = pyard.init("3440", data_dir="/tmp/py-ard")
 
     # an ard with ping set to True
-    my_config = {
+    ping_config = {
         "ping": True,
     }
-    context.ard_ping = pyard.init("3440", data_dir="/tmp/py-ard", config=my_config)
+    context.ard_ping = pyard.init("3440", data_dir="/tmp/py-ard", config=ping_config)
+
+    # an ard with ARS suffix for lg
+    lg_ars_config = {
+        "ARS_as_lg": True,
+    }
+    context.ard_ars = pyard.init("3440", data_dir="/tmp/py-ard", config=lg_ars_config)

--- a/tests/features/allele.feature
+++ b/tests/features/allele.feature
@@ -40,3 +40,20 @@ Feature: Alleles
       | C*02:10        | lg    | C*02:02g          |
       | C*02:10        | lgx   | C*02:02           |
       | C*06:17        | lgx   | C*06:17           |
+
+
+  Scenario Outline: allele reduction with ARS suffix
+
+    In `g` mode, use `ARS` prefix rather than `g`.
+
+    Given the allele as <Allele>
+    When reducing on the <Level> level with ARS suffix enabled
+    Then the reduced allele is found to be <Redux Allele>
+
+    Examples:
+      | Allele         | Level | Redux Allele   |
+      | A*01:01:01     | lg     | A*01:01ARS     |
+      | HLA-A*01:01:01 | lg     | HLA-A*01:01ARS |
+      | DRB1*14:06:01  | lg     | DRB1*14:06ARS  |
+      | C*02:02        | lg     | C*02:02ARS     |
+      | C*02:10        | lg     | C*02:02ARS     |

--- a/tests/features/allele.feature
+++ b/tests/features/allele.feature
@@ -7,12 +7,12 @@ Feature: Alleles
     Then the reduced allele is found to be <Redux Allele>
 
     Examples:
-      | Allele         | Level | Redux Allele      |
-      | C*02:02        | lg    | C*02:02g          |
-      | C*02:02        | lgx   | C*02:02           |
-      | C*02:10        | lg    | C*02:02g          |
-      | C*02:10        | lgx   | C*02:02           |
-      | C*06:17        | lgx   | C*06:02           |
+      | Allele  | Level | Redux Allele |
+      | C*02:02 | lg    | C*02:02g     |
+      | C*02:02 | lgx   | C*02:02      |
+      | C*02:10 | lg    | C*02:02g     |
+      | C*02:10 | lgx   | C*02:02      |
+      | C*06:17 | lgx   | C*06:02      |
 
   Scenario Outline: allele reduction
 
@@ -21,30 +21,30 @@ Feature: Alleles
     Then the reduced allele is found to be <Redux Allele>
 
     Examples:
-      | Allele         | Level | Redux Allele      |
-      | A*01:01:01     | G     | A*01:01:01G       |
-      | A*01:01:01     | lg    | A*01:01g          |
-      | A*01:01:01     | lgx   | A*01:01           |
+      | Allele         | Level | Redux Allele    |
+      | A*01:01:01     | G     | A*01:01:01G     |
+      | A*01:01:01     | lg    | A*01:01g        |
+      | A*01:01:01     | lgx   | A*01:01         |
 
-      | HLA-A*01:01:01 | G     | HLA-A*01:01:01G   |
-      | HLA-A*01:01:01 | lg    | HLA-A*01:01g      |
-      | HLA-A*01:01:01 | lgx   | HLA-A*01:01       |
+      | HLA-A*01:01:01 | G     | HLA-A*01:01:01G |
+      | HLA-A*01:01:01 | lg    | HLA-A*01:01g    |
+      | HLA-A*01:01:01 | lgx   | HLA-A*01:01     |
 
-      | DRB1*14:05:01  | lgx   | DRB1*14:05        |
-      | DRB1*14:05:01  | lg    | DRB1*14:05g       |
+      | DRB1*14:05:01  | lgx   | DRB1*14:05      |
+      | DRB1*14:05:01  | lg    | DRB1*14:05g     |
 
-      | DRB1*14:06:01  | lgx   | DRB1*14:06        |
-      | DRB1*14:06:01  | lg    | DRB1*14:06g       |
-      | C*02:02        | lg    | C*02:02g          |
-      | C*02:02        | lgx   | C*02:02           |
-      | C*02:10        | lg    | C*02:02g          |
-      | C*02:10        | lgx   | C*02:02           |
-      | C*06:17        | lgx   | C*06:17           |
+      | DRB1*14:06:01  | lgx   | DRB1*14:06      |
+      | DRB1*14:06:01  | lg    | DRB1*14:06g     |
+      | C*02:02        | lg    | C*02:02g        |
+      | C*02:02        | lgx   | C*02:02         |
+      | C*02:10        | lg    | C*02:02g        |
+      | C*02:10        | lgx   | C*02:02         |
+      | C*06:17        | lgx   | C*06:17         |
 
 
   Scenario Outline: allele reduction with ARS suffix
 
-    In `g` mode, use `ARS` prefix rather than `g`.
+  In `g` mode, use `ARS` prefix rather than `g`.
 
     Given the allele as <Allele>
     When reducing on the <Level> level with ARS suffix enabled
@@ -52,8 +52,8 @@ Feature: Alleles
 
     Examples:
       | Allele         | Level | Redux Allele   |
-      | A*01:01:01     | lg     | A*01:01ARS     |
-      | HLA-A*01:01:01 | lg     | HLA-A*01:01ARS |
-      | DRB1*14:06:01  | lg     | DRB1*14:06ARS  |
-      | C*02:02        | lg     | C*02:02ARS     |
-      | C*02:10        | lg     | C*02:02ARS     |
+      | A*01:01:01     | lg    | A*01:01ARS     |
+      | HLA-A*01:01:01 | lg    | HLA-A*01:01ARS |
+      | DRB1*14:06:01  | lg    | DRB1*14:06ARS  |
+      | C*02:02        | lg    | C*02:02ARS     |
+      | C*02:10        | lg    | C*02:02ARS     |

--- a/tests/steps/redux_allele.py
+++ b/tests/steps/redux_allele.py
@@ -42,6 +42,12 @@ def step_impl(context, level):
     context.redux_allele = context.ard_ping.redux(context.allele, level)
 
 
+@when("reducing on the {level} level with ARS suffix enabled")
+def step_impl(context, level):
+    context.level = level
+    context.redux_allele = context.ard_ars.redux(context.allele, level)
+
+
 @when("reducing on the {level} level (ambiguous)")
 def step_impl(context, level):
     context.level = level


### PR DESCRIPTION
`ARS_as_lg` as a config flag to allow **ARS** suffix instead of **g** for `lg` reduction mode.

Fixes #236 