### PR TITLE
Validate MAC codes is alpha before looking up in db

### DIFF
--- a/pyard/ard.py
+++ b/pyard/ard.py
@@ -23,6 +23,7 @@
 #
 import functools
 import re
+import sqlite3
 import sys
 from typing import Iterable, List
 
@@ -473,7 +474,11 @@ class ARD(object):
         """
         if ":" in allele:
             code = allele.split(":")[1]
-            return db.is_valid_mac_code(self.db_connection, code)
+            try:
+                if code.isalpha():
+                    return db.is_valid_mac_code(self.db_connection, code)
+            except sqlite3.OperationalError as e:
+                print("Error: ", e)
         return False
 
     def is_v2(self, allele: str) -> bool:


### PR DESCRIPTION
Try and validate MAC codes when code is alphabetical characters. This also helps when `py-ard` starts with no MAC codes.