### PR TITLE
Add `is_null` method to ARD

### DIFF
--- a/pyard/ard.py
+++ b/pyard/ard.py
@@ -529,6 +529,15 @@ class ARD(object):
         """
         return allele in self.shortnulls and self._config["reduce_shortnull"]
 
+    def is_null(self, allele):
+        """
+        Check if allele is a null allele.
+
+        @param allele: Allele to check for null
+        @return: boolean indicating whether allele is null or not
+        """
+        return allele.endswith("N") and not self.is_mac(allele)
+
     def is_exp_allele(self, allele):
         """
         Test if allele is valid as a shortening (WHO rules)

--- a/tests/test_pyard.py
+++ b/tests/test_pyard.py
@@ -186,3 +186,17 @@ class TestPyArd(unittest.TestCase):
             another_ard._redux_allele.cache_info().maxsize, higher_cache_size
         )
         self.assertEqual(another_ard.redux.cache_info().maxsize, higher_cache_size)
+
+    def test_is_null(self):
+        # a null allele
+        allele = "A*01:01N"
+        self.assertTrue(self.ard.is_null(allele))
+        # not null allele
+        allele = "A*01:01"
+        self.assertFalse(self.ard.is_null(allele))
+        # MACs ending with N shouldn't be called as Nulls
+        allele = "A*01:MN"
+        self.assertFalse(self.ard.is_null(allele))
+        # MACs shouldn't be called as Nulls
+        allele = "A*01:AB"
+        self.assertFalse(self.ard.is_null(allele))

--- a/tests/test_pyard.py
+++ b/tests/test_pyard.py
@@ -190,13 +190,18 @@ class TestPyArd(unittest.TestCase):
     def test_is_null(self):
         # a null allele
         allele = "A*01:01N"
-        self.assertTrue(self.ard.is_null(allele))
+        self.assertTrue(self.ard.is_null(allele), msg="A Null Allele")
         # not null allele
         allele = "A*01:01"
-        self.assertFalse(self.ard.is_null(allele))
+        self.assertFalse(self.ard.is_null(allele), msg="not null allele")
         # MACs ending with N shouldn't be called as Nulls
         allele = "A*01:MN"
-        self.assertFalse(self.ard.is_null(allele))
+        self.assertFalse(
+            self.ard.is_null(allele),
+            msg="MACs ending with N shouldn't be called as Nulls",
+        )
         # MACs shouldn't be called as Nulls
         allele = "A*01:AB"
-        self.assertFalse(self.ard.is_null(allele))
+        self.assertFalse(
+            self.ard.is_null(allele), msg="MACs shouldn't be called as Nulls"
+        )


### PR DESCRIPTION
Added `is_null(allele)` method to ARD to check for null allele.

Fixes #256 