### PR TITLE
Fix username on docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL MAINTAINER="Pradeep Bashyal"
 
 WORKDIR /app
 
-ARG PY_ARD_VERSION=1.0.3
+ARG PY_ARD_VERSION=1.0.4
 
 COPY requirements.txt /app
 RUN pip install --no-cache-dir --upgrade pip && \

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: ARD Reduction
   description: Reduce to ARD Level
-  version: "1.0.3"
+  version: "1.0.4"
 servers:
   - url: 'http://localhost:8080'
 tags:

--- a/pyard/__init__.py
+++ b/pyard/__init__.py
@@ -27,7 +27,7 @@ from .constants import DEFAULT_CACHE_SIZE
 from .misc import get_imgt_db_versions as db_versions
 
 __author__ = """NMDP Bioinformatics"""
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 
 
 def init(

--- a/pyard/misc.py
+++ b/pyard/misc.py
@@ -19,7 +19,7 @@
 #    > http://www.fsf.org/licensing/licenses/lgpl.html
 #    > http://www.opensource.org/licenses/lgpl-license.php
 #
-import os
+import getpass
 import pathlib
 import tempfile
 from typing import List
@@ -143,7 +143,10 @@ def get_imgt_version(imgt_version):
 
 
 def get_default_db_directory():
-    username = os.getlogin()
+    try:
+        username = getpass.getuser()
+    except OSError:
+        username = "nonuser"
     return pathlib.Path(tempfile.gettempdir()) / f"pyard-{username}"
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.3
+current_version = 1.0.4
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ with open("requirements-tests.txt") as requirements_file:
 
 setup(
     name="py-ard",
-    version="1.0.3",
+    version="1.0.4",
     description="ARD reduction for HLA with Python",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
When running without a login, `os.getlogin()` fails. Switch to using `getuser()` from `getpass` module.

Bump version: 1.0.3 → 1.0.4

Fixes #267 