### PR TITLE
Fix for V2s that are not valid

### DIFF
--- a/pyard/ard.py
+++ b/pyard/ard.py
@@ -535,13 +535,22 @@ class ARD(object):
         :param allele: Possible allele
         :return: Is the allele in V2 nomenclature
         """
-        return (
+        matches_v2_format = (
             self._config["reduce_v2"]
             and "*" in allele
             and ":" not in allele
             and allele.split("*")[0] not in ["MICA", "MICB", "HFE"]
-            and allele != self._map_v2_to_v3(allele)
         )
+
+        if matches_v2_format:
+            v3_format_allele = self._map_v2_to_v3(allele)
+            if v3_format_allele != allele:
+                # If the last field of the allele is alpha, check if it's a MAC
+                if v3_format_allele.split(":").pop().isalpha():
+                    return self.is_mac(v3_format_allele)
+                return self._is_valid_allele(v3_format_allele)
+
+        return False
 
     def _is_who_allele(self, allele):
         """

--- a/tests/features/version2.feature
+++ b/tests/features/version2.feature
@@ -2,15 +2,32 @@ Feature: Version 2 Nomenclature
 
   py-ard is able to reduce version 2 HLA nomenclature.
 
-  Scenario Outline:
+  Scenario Outline: Redux V2 Alleles
 
     Given the version 2 typing is <Version2>
     When reducing on the <Level> level (ambiguous)
     Then the reduced allele is found to be <Redux Allele>
 
 
-    Examples: Valid A serology typings
+    Examples: Reduce V2 Alleles
       | Version2  | Level | Redux Allele                                                   |
       | A*0105N   | G     | A*01:01:01G                                                    |
       | A*0111    | G     | A*01:11N                                                       |
       | DRB5*02ZB | G     | DRB5*01:02:01G/DRB5*01:03/DRB5*02:02:01G/DRB5*02:03/DRB5*02:04 |
+
+
+  Scenario Outline: Invalid V2
+
+  Alleles that have valid V2 format but when converted to V3 format,
+  is not a valid allele.
+
+    Given the version 2 typing is <Version2>
+    When validating the V2 typing
+    Then the validness of V2 typing is <Validity>
+
+    Examples: Validate
+      | Version2  | Validity |
+      | A*0105N   | Valid    |
+      | DQB1*0804 | Invalid  |
+      | A*01:AB   | Valid    |
+      | A*01:NOAB | Invalid  |

--- a/tests/steps/redux_allele.py
+++ b/tests/steps/redux_allele.py
@@ -22,7 +22,7 @@
 from behave import given, when, then
 from hamcrest import assert_that, is_
 
-from pyard.exceptions import PyArdError
+from pyard.exceptions import PyArdError, InvalidAlleleError
 
 
 @given("the allele as {allele}")
@@ -70,6 +70,20 @@ def step_impl(context, serology):
 @given("the version 2 typing is {v2_allele}")
 def step_impl(context, v2_allele):
     context.allele = v2_allele
+
+
+@when("validating the V2 typing")
+def step_impl(context):
+    try:
+        context.is_valid = context.ard.validate(context.allele)
+    except InvalidAlleleError:
+        context.is_valid = False
+
+
+@then("the validness of V2 typing is {validity}")
+def step_impl(context, validity):
+    valid = validity == "Valid"
+    assert_that(context.is_valid, is_(valid))
 
 
 @given("the typing is {allele}")


### PR DESCRIPTION
When given a V2 looking allele, eg DQB1*0804, validate it forms a valid V3 allele and validate that V3 format of the allele is valid.

Fixes #282 