### PR TITLE
Fix `validate()` in non-strict mode

### DIFF
--- a/tests/features/allele.feature
+++ b/tests/features/allele.feature
@@ -72,6 +72,21 @@ Feature: Alleles
       | A*24:329    | lgx   | A*24:329Q    |
       | DQB1*03:276 | lgx   | DQB1*03:01   |
 
+  Scenario Outline: Allele validation in non-strict mode
+
+    Similar to reduction, handle non-strict mode when validating an allele.
+    The test version of IPD/IMGT-HLA database (see environment.py),
+    A*11:403 is invalid and A*24:329 is valid for A*24:329Q
+
+    Given the allele as <Allele>
+    When checking for validity of the allele in non-strict mode
+    Then the validness of the allele is <Validity>
+
+    Examples:
+      | Allele   | Validity |
+      | A*11:403 | Invalid  |
+      | A*24:329 | Valid    |
+
 
   Scenario Outline: Single field MICA, MICB Alleles
 

--- a/tests/features/mac.feature
+++ b/tests/features/mac.feature
@@ -61,7 +61,7 @@ Feature: MAC (Multiple Allele Code)
 
     Given the MAC code is <MAC>
     When checking for validity of the MAC
-    Then the validness is <Validity>
+    Then the validness of MAC is <Validity>
 
     Examples:
       | MAC          | Validity |

--- a/tests/steps/mac.py
+++ b/tests/steps/mac.py
@@ -42,7 +42,7 @@ def step_impl(context):
         context.is_valid = False
 
 
-@then("the validness is {validity}")
+@then("the validness of MAC is {validity}")
 def step_impl(context, validity):
     valid = validity == "Valid"
     assert_that(context.is_valid, is_(valid))

--- a/tests/steps/redux_allele.py
+++ b/tests/steps/redux_allele.py
@@ -112,3 +112,17 @@ def step_impl(context, expanded_alleles):
 def step_impl(context, level):
     context.level = level
     context.redux_allele = context.ard_non_strict.redux(context.allele, level)
+
+
+@when("checking for validity of the allele in non-strict mode")
+def step_impl(context):
+    try:
+        context.is_valid = context.ard_non_strict.validate(context.allele)
+    except InvalidAlleleError:
+        context.is_valid = False
+
+
+@then("the validness of the allele is {validity}")
+def step_impl(context, validity):
+    valid = validity == "Valid"
+    assert_that(context.is_valid, is_(valid))


### PR DESCRIPTION
Allele validation in non-strict mode

- Fix an issue where `strict` flag  wasn't being checked.

Fixes #285 