### PR TITLE
Bump to 1.0.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL MAINTAINER="Pradeep Bashyal"
 
 WORKDIR /app
 
-ARG PY_ARD_VERSION=1.0.7
+ARG PY_ARD_VERSION=1.0.8
 
 COPY requirements.txt /app
 RUN pip install --no-cache-dir --upgrade pip && \

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: ARD Reduction
   description: Reduce to ARD Level
-  version: "1.0.7"
+  version: "1.0.8"
 servers:
   - url: 'http://localhost:8080'
 tags:

--- a/pyard/__init__.py
+++ b/pyard/__init__.py
@@ -27,7 +27,7 @@ from .constants import DEFAULT_CACHE_SIZE
 from .misc import get_imgt_db_versions as db_versions
 
 __author__ = """NMDP Bioinformatics"""
-__version__ = "1.0.7"
+__version__ = "1.0.8"
 
 
 def init(

--- a/scripts/pyard-import
+++ b/scripts/pyard-import
@@ -144,7 +144,7 @@ if __name__ == "__main__":
     del ard
 
     if v2_to_v3_dict:
-        db_connection = db.create_db_connection(data_dir, imgt_version, ro=False)
+        db_connection, _ = db.create_db_connection(data_dir, imgt_version, ro=False)
         db.save_dict(
             db_connection,
             table_name="v2_mapping",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.7
+current_version = 1.0.8
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ with open("requirements-tests.txt") as requirements_file:
 
 setup(
     name="py-ard",
-    version="1.0.7",
+    version="1.0.8",
     description="ARD reduction for HLA with Python",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
 - Bump version: 1.0.7 → 1.0.8
 - Fix `--v2-to-v3-mapping` failure