### PR TITLE
MAC lookup error

### DIFF
--- a/tests/test_pyard.py
+++ b/tests/test_pyard.py
@@ -210,4 +210,4 @@ class TestPyArd(unittest.TestCase):
         mac_code = "A*68:AJEBX"
         expanded_mac = self.ard.expand_mac(mac_code)
         lookup_mac = self.ard.lookup_mac(expanded_mac)
-        self.assertEqual(mac_code, lookup_mac)
+        self.assertEqual(mac_code, lookup_mac, msg="MACs should be reversible")

--- a/tests/test_pyard.py
+++ b/tests/test_pyard.py
@@ -205,3 +205,9 @@ class TestPyArd(unittest.TestCase):
         self.assertFalse(
             self.ard.is_null(allele), msg="MACs shouldn't be called as Nulls"
         )
+
+    def test_mac_is_reversible(self):
+        mac_code = "A*68:AJEBX"
+        expanded_mac = self.ard.expand_mac(mac_code)
+        lookup_mac = self.ard.lookup_mac(expanded_mac)
+        self.assertEqual(mac_code, lookup_mac)


### PR DESCRIPTION
 - Alleles need to be sorted when looking up in database
 - Allow the given order first

Fixes #313 