### PR TITLE
Fix `exon` reductions for 2 field alleles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL MAINTAINER="Pradeep Bashyal"
 
 WORKDIR /app
 
-ARG PY_ARD_VERSION=1.1.2
+ARG PY_ARD_VERSION=1.1.3
 
 COPY requirements.txt /app
 RUN pip install --no-cache-dir --upgrade pip && \

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: ARD Reduction
   description: Reduce to ARD Level
-  version: "1.1.2"
+  version: "1.1.3"
 servers:
   - url: 'http://localhost:8080'
 tags:

--- a/pyard/__init__.py
+++ b/pyard/__init__.py
@@ -26,7 +26,7 @@ from .constants import DEFAULT_CACHE_SIZE
 from .misc import get_imgt_db_versions as db_versions
 
 __author__ = """NMDP Bioinformatics"""
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 
 
 def init(

--- a/pyard/ard.py
+++ b/pyard/ard.py
@@ -258,8 +258,15 @@ class ARD(object):
 
                 return exon_group_allele
             else:
-                # for 'exon' return allele with only first 3 fields
-                return ":".join(allele.split(":")[0:3])
+                # Expand to W level and then reduce to exon
+                w_redux = self.redux(allele, "W")
+                # If the W redux produces 2 field allele or the same allele,
+                # don't recurse
+                if w_redux == allele or len(w_redux.split(":")) == 2:
+                    return allele
+                else:
+                    # recurse with the W fields
+                    return self.redux(w_redux, "exon")
         elif redux_type == "U2":
             allele_fields = allele.split(":")
             # If resolved out to second field leave alone

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.2
+current_version = 1.1.3
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ with open("requirements-tests.txt") as requirements_file:
 
 setup(
     name="py-ard",
-    version="1.1.2",
+    version="1.1.3",
     description="ARD reduction for HLA with Python",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/tests/features/who.feature
+++ b/tests/features/who.feature
@@ -22,10 +22,13 @@ Feature: WHO expansion and Exon reduction
 
   Scenario Outline: Exon reduction
 
+  Exon reductions will expand 2 field alleles to W level before generating
+  exon level reductions.
+
     Given the typing is <Allele>
     When expanding at the <Level> level
     Then the expanded allele is found to be <Expanded Alleles>
     Examples:
-      | Allele        | Level | Expanded Alleles |
-      | DRB1*11:01    | exon  | DRB1*11:01       |
-      | A*01:01:01:03 | exon  | A*01:01:01       |
+      | Allele        | Level | Expanded Alleles                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+      | A*01:01:01:03 | exon  | A*01:01:01                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+      | DRB1*11:01    | exon  | DRB1*11:01:01/DRB1*11:01:02/DRB1*11:01:03/DRB1*11:01:04/DRB1*11:01:05/DRB1*11:01:06/DRB1*11:01:07/DRB1*11:01:08/DRB1*11:01:09/DRB1*11:01:10/DRB1*11:01:11/DRB1*11:01:12/DRB1*11:01:13/DRB1*11:01:14/DRB1*11:01:15/DRB1*11:01:16/DRB1*11:01:17/DRB1*11:01:18/DRB1*11:01:19/DRB1*11:01:20/DRB1*11:01:21/DRB1*11:01:22/DRB1*11:01:23/DRB1*11:01:24/DRB1*11:01:25/DRB1*11:01:26/DRB1*11:01:27/DRB1*11:01:28/DRB1*11:01:29/DRB1*11:01:30/DRB1*11:01:31/DRB1*11:01:32/DRB1*11:01:33/DRB1*11:01:34/DRB1*11:01:35/DRB1*11:01:36/DRB1*11:01:37/DRB1*11:01:38/DRB1*11:01:39/DRB1*11:01:40/DRB1*11:01:41/DRB1*11:01:42/DRB1*11:01:43 |


### PR DESCRIPTION
Perform `W` reductions and then exon reductions when not already in exon mapping, e.g. for 2 field alleles

Fixes #320 