### PR TITLE
Ping reductions for duplicates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL MAINTAINER="Pradeep Bashyal"
 
 WORKDIR /app
 
-ARG PY_ARD_VERSION=1.2.0
+ARG PY_ARD_VERSION=1.2.1
 
 COPY requirements.txt /app
 RUN pip install --no-cache-dir --upgrade pip && \

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: ARD Reduction
   description: Reduce to ARD Level
-  version: "1.2.0"
+  version: "1.2.1"
 servers:
   - url: 'http://localhost:8080'
 tags:

--- a/pyard/__init__.py
+++ b/pyard/__init__.py
@@ -26,7 +26,7 @@ from .constants import DEFAULT_CACHE_SIZE
 from .misc import get_imgt_db_versions as db_versions
 
 __author__ = """NMDP Bioinformatics"""
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 
 
 def init(

--- a/pyard/ard.py
+++ b/pyard/ard.py
@@ -225,14 +225,18 @@ class ARD(object):
                         no_suffix_allele = redux_allele
                     if (
                         no_suffix_allele == allele
+                        or "/" in no_suffix_allele
                         or no_suffix_allele in self.ars_mappings.p_not_g.values()
                     ):
                         return redux_allele
-                    redux_allele = self._redux_allele(
-                        no_suffix_allele, redux_type, True
+
+                    twice_redux_allele = self._redux_allele(
+                        no_suffix_allele, redux_type, False
                     )
-                    if self._is_valid_allele(redux_allele):
-                        return redux_allele
+                    if "/" in twice_redux_allele:
+                        return twice_redux_allele
+                    if self._is_valid_allele(twice_redux_allele):
+                        return twice_redux_allele
 
         if redux_type == "G" and allele in self.ars_mappings.g_group:
             if allele in self.ars_mappings.dup_g:
@@ -338,6 +342,10 @@ class ARD(object):
                 raise InvalidAlleleError(f"{allele} is an invalid allele.")
 
     def _add_lg_suffix(self, redux_allele):
+        if "/" in redux_allele:
+            return "/".join(
+                [self._add_lg_suffix(allele) for allele in redux_allele.split("/")]
+            )
         # ARS suffix maybe used instead of g
         if self._config["ARS_as_lg"]:
             return redux_allele + "ARS"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.0
+current_version = 1.2.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ with open("requirements-tests.txt") as requirements_file:
 
 setup(
     name="py-ard",
-    version="1.2.0",
+    version="1.2.1",
     description="ARD reduction for HLA with Python",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/tests/features/p_g_group.feature
+++ b/tests/features/p_g_group.feature
@@ -13,17 +13,17 @@ Feature: P and G Groups
 
 
   Scenario Outline: allele reduction with ping
-    `ping` is the default.
+  `ping` is the default.
 
-    If there is no G group for the allele, it should use the P group allele.
+  If there is no G group for the allele, it should use the P group allele.
 
     Given the allele as <Allele>
     When reducing on the <Level> level with ping
     Then the reduced allele is found to be <Redux Allele>
 
     Examples:
-      | Allele           | Level | Redux Allele |
-      | C*06:17          | lgx   | C*06:02      |
+      | Allele  | Level | Redux Allele |
+      | C*06:17 | lgx   | C*06:02      |
 
     Examples: DRB4*01s
       | Allele           | Level | Redux Allele |
@@ -83,9 +83,17 @@ Feature: P and G Groups
       | DRB4*01:03:02:02 | lgx   | DRB4*01:01   |
 
     Examples: C*02:10s
-      | Allele           | Level | Redux Allele |
-      | C*02:10:02       | lgx   | C*02:02      |
-      | C*02:02          | lg    | C*02:02g     |
-      | C*02:02          | lgx   | C*02:02      |
-      | C*02:10          | lg    | C*02:02g     |
-      | C*02:10          | lgx   | C*02:02      |
+      | Allele     | Level | Redux Allele |
+      | C*02:10:02 | lgx   | C*02:02      |
+      | C*02:02    | lg    | C*02:02g     |
+      | C*02:02    | lgx   | C*02:02      |
+      | C*02:10    | lg    | C*02:02g     |
+      | C*02:10    | lgx   | C*02:02      |
+
+    Examples: lgx with duplicates
+      | Allele        | Level | Redux Allele            |
+      | DPA1*02:12    | lgx   | DPA1*02:02/DPA1*02:07   |
+      | DPA1*02:12    | lg    | DPA1*02:02g/DPA1*02:07g |
+      | DQA1*03:03    | lgx   | DQA1*03:01              |
+      | DQA1*03:03    | lg    | DQA1*03:01g             |
+      | DQA1*03:03:09 | lg    | DQA1*03:03g             |


### PR DESCRIPTION
Fix ping reductions
 - Some alleles have dupe reductions e.g. `DPA1*02:12` -> `DPA1*02:02/DPA1*02:07`

 Bump version: 1.2.0 → 1.2.1

Fixes #325 

