### PR TITLE
Only single `lgx` reductions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL MAINTAINER="Pradeep Bashyal"
 
 WORKDIR /app
 
-ARG PY_ARD_VERSION=1.5.1
+ARG PY_ARD_VERSION=1.5.2
 
 COPY requirements.txt /app
 RUN pip install --no-cache-dir --upgrade pip && \

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: ARD Reduction
   description: Reduce to ARD Level
-  version: "1.5.1"
+  version: "1.5.2"
 servers:
   - url: 'http://localhost:8080'
 tags:

--- a/pyard/__init__.py
+++ b/pyard/__init__.py
@@ -26,7 +26,7 @@ from .constants import DEFAULT_CACHE_SIZE
 from .misc import get_imgt_db_versions as db_versions
 
 __author__ = """NMDP Bioinformatics"""
-__version__ = "1.5.1"
+__version__ = "1.5.2"
 
 
 def init(

--- a/pyard/ard.py
+++ b/pyard/ard.py
@@ -246,9 +246,7 @@ class ARD(object):
         elif redux_type == "P" and allele in self.ars_mappings.p_group:
             return self.ars_mappings.p_group[allele]
         elif redux_type in ["lgx", "lg"]:
-            if allele in self.ars_mappings.dup_lgx:
-                redux_allele = self.ars_mappings.dup_lgx[allele]
-            elif allele in self.ars_mappings.lgx_group:
+            if allele in self.ars_mappings.lgx_group:
                 redux_allele = self.ars_mappings.lgx_group[allele]
             else:
                 # for 'lgx' or 'lg' mode when allele is not in G group,

--- a/pyard/ard.py
+++ b/pyard/ard.py
@@ -189,6 +189,8 @@ class ARD(object):
             hla, allele_name = allele.split("-")
             redux_allele = self._redux_allele(allele_name, redux_type)
             if redux_allele:
+                if "/" in redux_allele:
+                    return "/".join(["HLA-" + ra for ra in redux_allele.split("/")])
                 return "HLA-" + redux_allele
             else:
                 return redux_allele

--- a/pyard/data_repository.py
+++ b/pyard/data_repository.py
@@ -50,6 +50,7 @@ from .misc import (
     get_1field_allele,
 )
 from .serology import broad_splits_dna_mapping, SerologyMapping
+from .smart_sort import smart_sort_comparator
 
 
 def expression_reduce(df):
@@ -113,15 +114,6 @@ def generate_ard_mapping(db_connection: sqlite3.Connection, imgt_version) -> ARS
     mlgx = df_g_group.drop_duplicates(["2d", "lgx"])["2d"].value_counts()
     multiple_lgx_list = mlgx[mlgx > 1].index.to_list()
 
-    # Keep only the alleles that have more than 1 mapping
-    dup_lgx = (
-        df_g_group[df_g_group["2d"].isin(multiple_lgx_list)][["lgx", "2d"]]
-        .drop_duplicates()
-        .groupby("2d", as_index=True)
-        .agg("/".join)
-        .to_dict()["lgx"]
-    )
-
     # Extract G group mapping
     df_g = pd.concat(
         [
@@ -154,6 +146,24 @@ def generate_ard_mapping(db_connection: sqlite3.Connection, imgt_version) -> ARS
     )
     lgx_group = df_lgx.set_index("A")["lgx"].to_dict()
 
+    # Find the alleles that have more than 1 mapping
+    dup_lgx = (
+        df_g_group[df_g_group["2d"].isin(multiple_lgx_list)][["lgx", "2d"]]
+        .drop_duplicates()
+        .groupby("2d", as_index=True)
+        .agg(list)
+        .to_dict()["lgx"]
+    )
+    # Do not keep duplicate alleles for lgx. Issue #333
+    # DPA1*02:02/DPA1*02:07 ==> DPA1*02:02
+    #
+    lowest_numbered_dup_lgx = {
+        k: sorted(v, key=functools.cmp_to_key(smart_sort_comparator))[0]
+        for k, v in dup_lgx.items()
+    }
+    # Update the lgx_group with the allele with the lowest number
+    lgx_group.update(lowest_numbered_dup_lgx)
+
     # Extract exon mapping
     df_exon = pd.concat(
         [
@@ -164,7 +174,6 @@ def generate_ard_mapping(db_connection: sqlite3.Connection, imgt_version) -> ARS
 
     ars_mapping = ARSMapping(
         dup_g=dup_g,
-        dup_lgx=dup_lgx,
         g_group=g_group,
         p_group=p_group,
         lgx_group=lgx_group,

--- a/pyard/db.py
+++ b/pyard/db.py
@@ -461,9 +461,6 @@ def set_user_version(connection: sqlite3.Connection, version: int):
 
 def load_ars_mappings(db_connection):
     dup_g = load_dict(db_connection, table_name="dup_g", columns=("allele", "g_group"))
-    dup_lgx = load_dict(
-        db_connection, table_name="dup_lgx", columns=("allele", "lgx_group")
-    )
     g_group = load_dict(db_connection, table_name="g_group", columns=("allele", "g"))
     p_group = load_dict(db_connection, table_name="p_group", columns=("allele", "p"))
     lgx_group = load_dict(
@@ -475,7 +472,6 @@ def load_ars_mappings(db_connection):
     p_not_g = load_dict(db_connection, table_name="p_not_g", columns=("allele", "lgx"))
     return ARSMapping(
         dup_g=dup_g,
-        dup_lgx=dup_lgx,
         g_group=g_group,
         p_group=p_group,
         lgx_group=lgx_group,
@@ -496,12 +492,6 @@ def save_ars_mappings(db_connection: sqlite3.Connection, ars_mapping: ARSMapping
         table_name="dup_g",
         dictionary=ars_mapping.dup_g,
         columns=("allele", "g_group"),
-    )
-    save_dict(
-        db_connection,
-        table_name="dup_lgx",
-        dictionary=ars_mapping.dup_lgx,
-        columns=("allele", "lgx_group"),
     )
     save_dict(
         db_connection,

--- a/pyard/mappings.py
+++ b/pyard/mappings.py
@@ -23,7 +23,6 @@ from collections import namedtuple
 
 ars_mapping_tables = [
     "dup_g",
-    "dup_lgx",
     "g_group",
     "p_group",
     "lgx_group",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.5.1
+current_version = 1.5.2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ with open("requirements-tests.txt") as requirements_file:
 
 setup(
     name="py-ard",
-    version="1.5.1",
+    version="1.5.2",
     description="ARD reduction for HLA with Python",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/tests/features/p_g_group.feature
+++ b/tests/features/p_g_group.feature
@@ -90,10 +90,10 @@ Feature: P and G Groups
       | C*02:10    | lg    | C*02:02g     |
       | C*02:10    | lgx   | C*02:02      |
 
-    Examples: lgx with duplicates
-      | Allele        | Level | Redux Allele            |
-      | DPA1*02:12    | lgx   | DPA1*02:02/DPA1*02:07   |
-      | DPA1*02:12    | lg    | DPA1*02:02g/DPA1*02:07g |
-      | DQA1*03:03    | lgx   | DQA1*03:01              |
-      | DQA1*03:03    | lg    | DQA1*03:01g             |
-      | DQA1*03:03:09 | lg    | DQA1*03:03g             |
+    Examples: lgx redux with duplicate G groups
+      | Allele        | Level | Redux Allele |
+      | DPA1*02:12    | lgx   | DPA1*02:02   |
+      | DPA1*02:12    | lg    | DPA1*02:02g  |
+      | DQA1*03:03    | lgx   | DQA1*03:01   |
+      | DQA1*03:03    | lg    | DQA1*03:01g  |
+      | DQA1*03:03:09 | lg    | DQA1*03:03g  |


### PR DESCRIPTION
## Only single `lgx` reductions

- For `lgx` reduction, tracking of duplicate alleles is removed. For duplicate alleles, map it to the lower numbered allele in the list for lgx group.


|Allele|Allele  List|Lowest Numbered Allele|
|------|------------|----------------------|
|`DPA1*02:07` | `DPA1*02:02/DPA1*02:07` | `DPA1*02:02` |
|`DPA1*02:12` | `DPA1*02:02/DPA1*02:07` | `DPA1*02:02` |
|`DQA1*03:03` | `DQA1*03:01/DQA1*03:03` | `DQA1*03:01` |


- Apply HLA- prefix correctly if the result is an allele list
-  Bump version: 1.5.1 → 1.5.2

Fixes #333 