### PR TITLE
`/ard/{allele}` endpoint for `lgx` reduction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL MAINTAINER="Pradeep Bashyal"
 
 WORKDIR /app
 
-ARG PY_ARD_VERSION=1.5.2
+ARG PY_ARD_VERSION=1.5.3
 
 COPY requirements.txt /app
 RUN pip install --no-cache-dir --upgrade pip && \

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -36,22 +36,35 @@ paths:
             application/json:
               schema:
                 properties:
-                 ipd-version:
+                 ipd_version:
                     description: IPD-IMGT/HLA DB Version
                     type: integer
-                    example: 3560
-                 py-ard-version:
+                    example: 3580
+                 pyard_version:
                     description: py-ard library version
                     type: string
-                    example: "1.2.1"
+                    example: "1.5.0"
   /redux:
     post:
       tags:
         - ARD Reduction
       operationId: api.redux_controller
-      summary: Reduce to ARD
+      summary: Reduce GL String at various level
       description: |
-        Given a GL String and a reduction method perform ARD Reduction
+        Given a GL String and a reduction method perform Reduction.
+
+        Valid Reduction Method:
+        | Reduction Type | Description                                               |
+        |----------------|-----------------------------------------------------------|
+        | `G`            | Reduce to G Group Level                                   |
+        | `P`            | Reduce to P Group Level                                   |
+        | `lg`           | Reduce to 2 field ARD level (append `g`)                  |
+        | `lgx`          | Reduce to 2 field ARD level                               |
+        | `W`            | Reduce/Expand to full field(4,3,2) WHO nomenclature level |
+        | `exon`         | Reduce/Expand to 3 field level                            |
+        | `U2`           | Reduce to 2 field unambiguous level                       |
+        | `S`            | Reduce to Serological level                               |
+
       requestBody:
         content:
           application/json:
@@ -88,6 +101,58 @@ paths:
                     example: "A*01:01+A*01:01^B*07:02+B*08:01^C*02:02/C*02:10+C*07:01/C*07:150Q^DPB1*28:01+DPB1*28:01"
         400:
           description: Invalid GL String Form
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    description: Describes what went wrong
+                    type: string
+                    example: "Invalid HLA locus"
+  /ard/{allele}:
+    get:
+      tags:
+        - ARD Reduction
+      operationId: api.lgx_controller
+      summary: Reduce to ARD
+      description: |
+        Get ARD Reduction for an Allele
+      parameters:
+        - name: allele
+          in: path
+          description: An allele or MAC
+          required: true
+          schema:
+            type: string
+          example: "DPA1*02:07:01"
+      responses:
+        200:
+          description: ARD Reduction Result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  allele:
+                    description: Allele
+                    type: string
+                    example: "DPA1*02:07:01"
+                  ard:
+                    description: ARD version
+                    type: string
+                    example: "DPA1*02:02"
+                  ipd_version:
+                    description: IPD-IMGT/HLA DB Version
+                    type: integer
+                    example: 3580
+                  pyard_version:
+                    description: py-ard library version
+                    type: string
+                    example: "1.2.1"
+
+        400:
+          description: Invalid Allele
           content:
             application/json:
               schema:

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: ARD Reduction
   description: Reduce to ARD Level
-  version: "1.5.2"
+  version: "1.5.3"
 servers:
   - url: 'http://localhost:8080'
 tags:

--- a/api.py
+++ b/api.py
@@ -58,6 +58,24 @@ def redux_controller():
     return {"message": "No input data provided"}, 404
 
 
+def lgx_controller(allele):
+    # Perform redux
+    if allele:
+        try:
+            redux_string = ard.redux(allele, "lgx")
+            ipd_version = ard.get_db_version()
+            return {
+                "ipd_version": ipd_version,
+                "pyard_version": pyard.__version__,
+                "allele": allele,
+                "ard": redux_string,
+            }, 200
+        except PyArdError as e:
+            return {"message": e.message}, 400
+    else:
+        return {"message": f"No allele provided"}, 404
+
+
 def mac_expand_controller(allele_code: str):
     try:
         if ard.is_mac(allele_code):
@@ -107,8 +125,8 @@ def drbx_blender_controller():
 def version_controller():
     ipd_version = ard.get_db_version()
     return {
-        "ipd-version": ipd_version,
-        "py-ard-version": pyard.__version__,
+        "ipd_version": ipd_version,
+        "pyard_version": pyard.__version__,
     }, 200
 
 

--- a/pyard/__init__.py
+++ b/pyard/__init__.py
@@ -26,7 +26,7 @@ from .constants import DEFAULT_CACHE_SIZE
 from .misc import get_imgt_db_versions as db_versions
 
 __author__ = """NMDP Bioinformatics"""
-__version__ = "1.5.2"
+__version__ = "1.5.3"
 
 
 def init(

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.5.2
+current_version = 1.5.3
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ with open("requirements-tests.txt") as requirements_file:
 
 setup(
     name="py-ard",
-    version="1.5.2",
+    version="1.5.3",
     description="ARD reduction for HLA with Python",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
- Add `/ard` GET endpoint that `lgx` reduces the allele in path.
    e.g. `http://127.0.0.1:8080/ard/DPA1*02:07:01`
    gives you:
    ```json
    {
      "allele": "DPA1*02:07:01",
      "ard": "DPA1*02:02",
      "ipd_version": 3580,
      "pyard_version": "1.5.2"
    }
    ```
    
    Makes it easy to create a `lgx` reduction URL to share.

-  Bump version: 1.5.2 → 1.5.3
