### PR TITLE
Fix issue when floating point numbers are present in batch

### DIFF
--- a/scripts/pyard-reduce-csv
+++ b/scripts/pyard-reduce-csv
@@ -121,7 +121,15 @@ def redux(allele, locus, column_name):
             if ":" in allele:
                 locus_allele = f"{locus}*{allele}"
             else:
-                locus_allele = f"{locus}{allele}"  # serology
+                if allele.isnumeric():
+                    # Serology alleles are all numeric
+                    locus_allele = f"{locus}{allele}"  # serology
+                else:
+                    # Watch out, we may get floats when exported from Excel.
+                    message = f"Failed reducing '{allele}' in column {column_name}"
+                    print(message)
+                    failed_to_reduce_alleles.append((column_name, allele))
+                    return allele
 
     # Check the config if this allele should be reduced
     if should_be_reduced(allele, locus_allele):


### PR DESCRIPTION
Correctly marks as a failure for invalid serology.
```
Using config file: conf.json
Column:R_A_TYP1 =>
	A*02:01 => A*02:01
Column:R_A_TYP2 =>
	A*02:01 => A*02:01
Column:R_B_TYP1 =>
	B*13:02 => B*13:02
Column:R_B_TYP2 =>
	B*50:01:00 => B*50:01
Column:R_C_TYP1 =>
	C*06:02 => C*06:02
Column:R_C_TYP2 =>
	C*06:02 => C*06:02
Column:R_DRB1_TYP1 =>
	DRB1*07:01 => DRB1*07:01
Column:R_DRB1_TYP2 =>
	DRB1*13:01 => DRB1*13:01
Column:R_DQB1_TYP1 =>
	DQB1*02:02 => DQB1*02:01
Column:R_DQB1_TYP2 =>
Failed reducing '0.478472222' in column R_DQB1_TYP2
Summary
-------
1 alleles failed to reduce.
| Column  Name    |      Allele      |      Did you mean ?       
| --------------- | ---------------- | ------------------------- 
| R_DQB1_TYP2     | 0.478472222      | NA 
Saved result to file:data/test.gl.csv.gz
```

Fixes #339 