### PR TITLE
Fix `HLA-` prefix on no result

### DIFF
--- a/pyard/ard.py
+++ b/pyard/ard.py
@@ -274,7 +274,8 @@ class ARD(object):
         if is_hla_prefix:
             if "/" in redux_allele:
                 return "/".join([f"HLA-{ra}" for ra in redux_allele.split("/")])
-            redux_allele = f"HLA-{redux_allele}"
+            if redux_allele:
+                redux_allele = f"HLA-{redux_allele}"
         return redux_allele
 
     @staticmethod

--- a/tests/features/allele.feature
+++ b/tests/features/allele.feature
@@ -111,3 +111,19 @@ Feature: Alleles
     Examples:
       | Allele    | Validity |
       | DRBX*NNNN | Valid    |
+
+  Scenario Outline: Preserve HLA Prefix
+    Given the allele as <Allele>
+    When reducing on the <Level> level
+    Then the reduced allele is found to be <Redux Allele>
+
+    Examples:
+      | Allele       | Level | Redux Allele                          |
+      | HLA-A*01:04N | lgx   | HLA-A*01:01                           |
+      | HLA-A*01:04N | P     | HLA-A*01:04:01:01N/HLA-A*01:04:01:02N |
+      | HLA-A*01:04N | G     | HLA-A*01:01:01G                       |
+      | HLA-A*01:04N | lg    | HLA-A*01:01g                          |
+      | HLA-A*01:04N | W     | HLA-A*01:04:01:01N/HLA-A*01:04:01:02N |
+      | HLA-A*01:04N | exon  | HLA-A*01:04:01N                       |
+      | HLA-A*01:04N | U2    | HLA-A*01:04N                          |
+      | HLA-A*01:04N | S     | X                                     |

--- a/tests/steps/redux_allele.py
+++ b/tests/steps/redux_allele.py
@@ -33,7 +33,11 @@ def step_impl(context, allele):
 @when("reducing on the {level} level")
 def step_impl(context, level):
     context.level = level
-    context.redux_allele = context.ard.redux(context.allele, level)
+    redux_allele = context.ard.redux(context.allele, level)
+    if redux_allele:
+        context.redux_allele = redux_allele
+    else:
+        context.redux_allele = "X"
 
 
 @when("reducing on the {level} level with ping")
@@ -56,7 +60,11 @@ def step_impl(context, level):
 def step_impl(context, level):
     context.level = level
     try:
-        context.redux_allele = context.ard.redux(context.allele, level)
+        redux_allele = context.ard.redux(context.allele, level)
+        if redux_allele:
+            context.redux_allele = redux_allele
+        else:
+            context.redux_allele = "X"
     except PyArdError:
         context.redux_allele = "X"
 


### PR DESCRIPTION
When allele has `HLA-` prefix, if the reduction is not available, do not have `HLA-` prefix.

Fixes #367 