### PR TITLE
MAC reduction in `ARS_as_lg` mode

### DIFF
--- a/pyard/smart_sort.py
+++ b/pyard/smart_sort.py
@@ -84,8 +84,15 @@ def smart_sort_comparator(a1, a2, ignore_suffixes=()):
 
     # Remove expression characters (P, N, Q, L, S, G, g) for comparison
     # This normalizes alleles like 'A*01:01N' to 'A*01:01' for sorting
-    a1 = re.sub(expr_regex, "", a1)
-    a2 = re.sub(expr_regex, "", a2)
+    if a1.endswith("ARS"):
+        a1 = a1[:-3]
+    else:
+        a1 = re.sub(expr_regex, "", a1)
+
+    if a2.endswith("ARS"):
+        a2 = a2[:-3]
+    else:
+        a2 = re.sub(expr_regex, "", a2)
 
     # Check equality again after removing expression characters
     if a1 == a2:

--- a/pyard/smart_sort.py
+++ b/pyard/smart_sort.py
@@ -82,10 +82,17 @@ def smart_sort_comparator(a1, a2, ignore_suffixes=()):
         if fields in ignore_suffixes:
             return -1  # a2 comes after a1
 
-    # Remove expression characters (P, N, Q, L, S, G, g) for comparison
+    # Remove expression characters (P, N, Q, L, S, G, g, ARS) for comparison
     # This normalizes alleles like 'A*01:01N' to 'A*01:01' for sorting
-    a1 = re.sub(expr_regex, "", a1)
-    a2 = re.sub(expr_regex, "", a2)
+    if a1.endswith("ARS"):
+        a1 = a1[:-3]
+    else:
+        a1 = re.sub(expr_regex, "", a1)
+
+    if a2.endswith("ARS"):
+        a2 = a2[:-3]
+    else:
+        a2 = re.sub(expr_regex, "", a2)
 
     # Check equality again after removing expression characters
     if a1 == a2:

--- a/tests/features/allele.feature
+++ b/tests/features/allele.feature
@@ -37,12 +37,13 @@ Feature: Alleles
     Then the reduced allele is found to be <Redux Allele>
 
     Examples:
-      | Allele         | Level | Redux Allele   |
-      | A*01:01:01     | lg    | A*01:01ARS     |
-      | HLA-A*01:01:01 | lg    | HLA-A*01:01ARS |
-      | DRB1*14:06:01  | lg    | DRB1*14:06ARS  |
-      | C*02:02        | lg    | C*02:02ARS     |
-      | C*02:10        | lg    | C*02:02ARS     |
+      | Allele         | Level | Redux Allele          |
+      | A*01:01:01     | lg    | A*01:01ARS            |
+      | HLA-A*01:01:01 | lg    | HLA-A*01:01ARS        |
+      | DRB1*14:06:01  | lg    | DRB1*14:06ARS         |
+      | C*02:02        | lg    | C*02:02ARS            |
+      | C*02:10        | lg    | C*02:02ARS            |
+      | A*01:AB        | lg    | A*01:01ARS/A*01:02ARS |
 
   Scenario Outline: Allele reduction in non-strict mode
 


### PR DESCRIPTION
Fixes Issues with MAC reduction:
- When `ARS_as_lg` is turned on for `ARS` suffix, it would fail in smart-sorting.