### PR TITLE
Support for addition of HATS in `rel_dna_ser.txt`

### DIFF
--- a/pyard/data_repository.py
+++ b/pyard/data_repository.py
@@ -430,25 +430,29 @@ def generate_serology_mapping(
 
         # Create a mapping of serology to alleles, lgx_alleles and associated XX allele
         serology_xx_mapping = serology_mapping.get_xx_mappings()
+        # Create a mapping of `serology` to tuple of:
+        #     allele_list
+        #     lgx_allele_list
+        #     xx
         # re-sort allele lists into smart-sort order
+        for sero in sero_mapping:
+            sero_mapping[sero] = (
+                "/".join(
+                    sorted(
+                        sero_mapping[sero][0],
+                        key=functools.cmp_to_key(smart_sort_comparator),
+                    )
+                ),
+                "/".join(
+                    sorted(
+                        sero_mapping[sero][1],
+                        key=functools.cmp_to_key(smart_sort_comparator),
+                    ),
+                ),
+                serology_xx_mapping[sero] if sero in serology_xx_mapping else None,
+            )
         for sero in serology_xx_mapping:
-            if sero in sero_mapping:
-                sero_mapping[sero] = (
-                    "/".join(
-                        sorted(
-                            sero_mapping[sero][0],
-                            key=functools.cmp_to_key(smart_sort_comparator),
-                        )
-                    ),
-                    "/".join(
-                        sorted(
-                            sero_mapping[sero][1],
-                            key=functools.cmp_to_key(smart_sort_comparator),
-                        ),
-                    ),
-                    serology_xx_mapping[sero],
-                )
-            else:
+            if sero not in sero_mapping:
                 sero_mapping[sero] = (None, None, serology_xx_mapping[sero])
 
         db.save_serology_mappings(db_connection, sero_mapping)

--- a/pyard/db.py
+++ b/pyard/db.py
@@ -585,7 +585,7 @@ def save_serology_mappings(db_connection, sero_mapping):
                             serology TEXT PRIMARY KEY,
                             allele_list TEXT,
                             lgx_allele_list TEXT,
-                            xx TEXT NOT NULL
+                            xx TEXT
                     )"""
     cursor.execute(create_table_sql)
 

--- a/pyard/loader/__init__.py
+++ b/pyard/loader/__init__.py
@@ -1,2 +1,7 @@
 # GitHub URL where IPD/IMGT-HLA files are downloaded.
-IMGT_HLA_URL = "https://raw.githubusercontent.com/ANHIG/IMGTHLA/"
+import os
+
+DEFAULT_IMGT_HLA_URL = "https://raw.githubusercontent.com/ANHIG/IMGTHLA/"
+IMGT_HLA_URL = os.getenv("IMGT_HLA_URL", DEFAULT_IMGT_HLA_URL)
+if IMGT_HLA_URL != DEFAULT_IMGT_HLA_URL:
+    print(f"Using URL: {IMGT_HLA_URL}")

--- a/pyard/loader/serology.py
+++ b/pyard/loader/serology.py
@@ -4,42 +4,26 @@ from urllib.error import URLError
 from urllib.request import urlopen
 
 from ..simple_table import Table
-
-# GitHub URL where IMGT HLA files are downloaded.
-IMGT_HLA_URL = "https://raw.githubusercontent.com/ANHIG/IMGTHLA/"
+from ..loader import IMGT_HLA_URL
 
 
 def load_serology_mappings(imgt_version):
     """
     Read `rel_dna_ser.txt` file that contains alleles and their serological equivalents.
-
-    # file: rel_dna_ser.txt
-    # date: 2025-10-08
-    # version: IPD-IMGT/HLA 3.62.0
-    # origin: http://hla.alleles.org/wmda/rel_dna_ser.txt
-    # repository: https://raw.githubusercontent.com/ANHIG/IMGTHLA/Latest/wmda/rel_dna_ser.txt
-    # author: WHO, Steven G. E. Marsh (steven.marsh@ucl.ac.uk)
-    A*;01:01:01:01;1;;;
-    A*;01:01:01:02N;0;;;
-    A*;01:01:01:03;1;;;
-    A*;01:01:01:04;1;;;
-    A*;01:01:01:05;1;;;
-    A*;01:01:01:06;1;;;
-    A*;01:01:01:07;1;;;
-    A*;01:01:01:08;1;;;
-    A*;01:01:01:09;1;;;
-    A*;01:01:01:10;1;;;
-    A*;01:01:01:11;1;;;
-
     The fields of the Alleles->Serological mapping file are:
-       Locus - HLA Locus
-       Allele - HLA Allele Name
-       USA - Unambiguous Serological Antigen associated with allele
-       PSA - Possible Serological Antigen associated with allele
-       ASA - Assumed Serological Antigen associated with allele
-       EAE - Expert Assigned Exceptions in search determinants of some registries
-
+    |--------|----------------------------------------------------------------------|
+    | Field  | Description                                                          |
+    |--------|----------------------------------------------------------------------|
+    | Locus  | HLA Locus                                                            |
+    | Allele | HLA Allele Name                                                      |
+    | USA    | Unambiguous Serological Antigen associated with allele               |
+    | PSA    | Possible Serological Antigen associated with allele                  |
+    | ASA    | Assumed Serological Antigen associated with allele                   |
+    | EAE    | Expert Assigned Exceptions in search determinants of some registries |
+    | HATS   | Assigned specificity as calculated by HATS                           |
+    |--------|----------------------------------------------------------------------|
     EAE is ignored when generating the serology map.
+    HATS is ignored when generating the serology map.
 
     :param imgt_version: IMGT database version
     :return: Table object with serology mapping data
@@ -56,7 +40,9 @@ def load_serology_mappings(imgt_version):
 
         # Convert semicolon-separated data to list of tuples
         # Original format: "A;A*01:01:01:01;A1;A1;;"
+        # Version >= IPD-IMGT/HLA 3.64.0: "A*;01:01:01:01;1;;;;1"
         data_tuples = []
+        columns = []
         for line in data_lines:
             if not line:
                 continue
@@ -66,12 +52,14 @@ def load_serology_mappings(imgt_version):
                 # Extract 7 fields as tuple, replace empty strings with None
                 rel_dna_fields = tuple(field if field else None for field in fields)
                 data_tuples.append(rel_dna_fields)
-                columns = ["Locus", "Allele", "USA", "PSA", "ASA", "EAE", "HATS"]
+                if not columns:
+                    columns = ["Locus", "Allele", "USA", "PSA", "ASA", "EAE", "HATS"]
             elif len(fields) == 6:
                 # Extract 6 fields as tuple, replace empty strings with None
                 rel_dna_fields = tuple(field if field else None for field in fields)
                 data_tuples.append(rel_dna_fields)
-                columns = ["Locus", "Allele", "USA", "PSA", "ASA", "EAE"]
+                if not columns:
+                    columns = ["Locus", "Allele", "USA", "PSA", "ASA", "EAE"]
         return Table(data_tuples, columns)
     except URLError as e:
         print(f"Error downloading {rel_dna_ser_url}", e, file=sys.stderr)

--- a/pyard/loader/version.py
+++ b/pyard/loader/version.py
@@ -1,13 +1,13 @@
 import sys
 from urllib.error import URLError
 
+from ..loader import IMGT_HLA_URL
+
 
 def load_latest_version():
     from urllib.request import urlopen
 
-    version_txt = (
-        "https://raw.githubusercontent.com/ANHIG/IMGTHLA/Latest/release_version.txt"
-    )
+    version_txt = f"{IMGT_HLA_URL}/Latest/release_version.txt"
     try:
         response = urlopen(version_txt)
     except URLError as e:

--- a/requirements-deploy.txt
+++ b/requirements-deploy.txt
@@ -1,4 +1,4 @@
 connexion[flask,swagger-ui,uvicorn]==3.3.0
 flask>=3.1.0
-uvicorn>=0.41.0
-gunicorn==25.1.0
+uvicorn>=0.45.0
+gunicorn==25.3.0

--- a/scripts/pyard-status
+++ b/scripts/pyard-status
@@ -108,6 +108,6 @@ if __name__ == "__main__":
                     total_rows = db.count_rows(db_connection, table)
                     print(f"|{table:30}|{int(total_rows):12,d}|")
                 else:
-                    print(f"MISSING: {table} table")
+                    print(f"|{table:30}| --MISSING--|")
             print("-" * LONG_DASH_LINE_LENGTH)
             db_connection.close()

--- a/tests/unit/test_load_serology_mappings.py
+++ b/tests/unit/test_load_serology_mappings.py
@@ -37,6 +37,47 @@ B*;01:01:01:05;1;;;
         assert alleles[4] == "02:1068Q"
 
 
+def test_load_serology_mappings_with_HATS_success():
+    mock_data = """
+# file: rel_dna_ser.txt
+# date: 2026-04-16
+# version: IPD-IMGT/HLA 3.64.0
+# origin: http://hla.alleles.org/wmda/rel_dna_ser.txt
+# repository: https://raw.githubusercontent.com/ANHIG/IMGTHLA/Latest/wmda/rel_dna_ser.txt
+# author: IPD Team (ipdsubs@anthonynolan.org)
+A*;01:01:01:01;1;;;;1
+A*;01:01:01:02N;0;;;;
+A*;01:01:01:03;1;;;;1
+A*;01:01:01:04;1;;;;1
+A*;02:04:02;2;;;;0201
+A*;02:03:18;0203;;;;0203
+B*;07:03;0703;;;;0703
+    """.strip()
+    with patch("pyard.loader.serology.urlopen") as mock_urlopen:
+        mock_urlopen.return_value = mock_data.encode().split(b"\n")
+
+        result = load_serology_mappings("3640")
+
+        assert isinstance(result, Table)
+        loci = result["Locus"]
+        alleles = result["Allele"]
+        usa = result["USA"]
+        hats = result["HATS"]
+        assert len(loci) == 7
+        assert loci[0] == "A*"
+        assert alleles[0] == "01:01:01:01"
+        assert usa[0] == "1"
+        assert loci[4] == "A*"
+        assert alleles[4] == "02:04:02"
+        assert hats[4] == "0201"
+        assert loci[5] == "A*"
+        assert alleles[5] == "02:03:18"
+        assert hats[5] == "0203"
+        assert loci[6] == "B*"
+        assert alleles[6] == "07:03"
+        assert hats[6] == "0703"
+
+
 def test_load_serology_mappings_empty_lines():
     mock_data = """
 # header line 1


### PR DESCRIPTION
Support for addition of HATS in `rel_dna_ser.txt` with the release of IPT/IMGT-HLA 3.64.0

- Handle the addition of HATS column
- New Serology may not have XX versions (`xx` column nullable in `serology_mapping` table)
- Support loading of data from local filesystem for testing
- `test_load_serology_mappings_with_HATS_success` to handle addition of HATS column

Fixes #381 
