### PR TITLE
G group validation consistency in strict/non-strict mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL MAINTAINER="Pradeep Bashyal"
 
 WORKDIR /app
 
-ARG PY_ARD_VERSION=2.1.1
+ARG PY_ARD_VERSION=2.2.0
 
 COPY requirements.txt /app
 RUN pip install --no-cache-dir --upgrade pip && \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT_NAME := $(shell basename `pwd`)
 PACKAGE_NAME := pyard
-PYARD_VERSION := 2.1.1
+PYARD_VERSION := 2.2.0
 
 .PHONY: clean clean-test clean-pyc clean-build docs help
 .DEFAULT_GOAL := help

--- a/README.md
+++ b/README.md
@@ -321,6 +321,19 @@ ard.is_shortnull('A*01:01N') # Check if short null
 ard.is_null('A*01:01N')      # Check if null allele
 ```
 
+Validate an allele:
+
+```python
+ard.is_valid_allele('A*01:01:01')  # True - valid 3-field allele
+ard.is_valid_allele('A*01:01')     # True - valid 2-field allele
+ard.is_valid_allele('A*01:01:01G') # True - valid G group allele
+ard.is_valid_allele('A*01:01P')    # True - valid P group allele
+ard.is_valid_allele('A*01:01g')    # True - valid lg allele (non-strict mode)
+ard.is_valid_allele('A*99:99')     # False - allele not in database
+```
+
+`is_valid_allele` checks whether an allele exists in the IPD-IMGT/HLA database. It handles G group (suffix `G`), P group (suffix `P`), and lg (suffix `g`) allele designations. In strict mode, G and P group alleles are validated against their respective group mappings. For alleles with more than 2 fields, it falls back to checking the 2-field version if the full allele is not found.
+
 Find serology relationships:
 
 ```python

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: ARD Reduction
   description: Reduce to ARD Level
-  version: "2.1.1"
+  version: "2.2.0"
 servers:
   - url: 'http://localhost:8080'
 tags:

--- a/pyard/__init__.py
+++ b/pyard/__init__.py
@@ -28,7 +28,7 @@ from .constants import DEFAULT_CACHE_SIZE
 from .misc import get_imgt_db_versions as db_versions
 
 __author__ = """NMDP Bioinformatics"""
-__version__ = "2.1.1"
+__version__ = "2.2.0"
 
 
 def init(

--- a/pyard/ard.py
+++ b/pyard/ard.py
@@ -147,7 +147,7 @@ class ARD(object):
             allele = self._get_non_strict_allele(allele)
 
         # Handle P/G suffixes
-        if allele.endswith(("P", "G")) and redux_type in ["lg", "lgx", "G"]:
+        if allele.endswith(("P", "G")) and redux_type in ["lg", "lgx", "G", "P"]:
             allele = allele[:-1]
 
         # Handle ping mode

--- a/pyard/ard.py
+++ b/pyard/ard.py
@@ -143,7 +143,7 @@ class ARD(object):
         self, allele: str, redux_type: VALID_REDUCTION_TYPE, re_ping=True
     ) -> str:
         """Core allele reduction with ping logic"""
-        if not self.config.strict:
+        if not self.config.strict_enabled:
             allele = self._get_non_strict_allele(allele)
 
         # Handle P/G suffixes
@@ -345,14 +345,37 @@ class ARD(object):
         return allele in self.allele_group.alleles
 
     def is_valid_allele(self, allele: str) -> bool:
-        if allele.endswith(("P", "G")):
+        """Check whether an allele exists in the IPD-IMGT/HLA database.
+
+        Handles G group (suffix 'G'), P group (suffix 'P'), and lg (suffix 'g')
+        allele designations. In strict mode, G and P group alleles are validated
+        against their respective group mappings. For alleles with more than 2
+        fields, falls back to checking the 2-field version if the full allele
+        is not found.
+
+        Args:
+            allele: An HLA allele string (e.g. 'A*01:01', 'A*01:01:01G').
+
+        Returns:
+            True if the allele is valid, False otherwise.
+        """
+        if allele.endswith("G"):
+            if self.config.strict_enabled:
+                return allele in self.ars_mappings.g_group.values()
             allele = allele[:-1]
-        if not self.config.strict and allele.endswith("g"):
+        elif allele.endswith("P"):
+            if self.config.strict_enabled:
+                return allele in self.ars_mappings.p_group.values()
             allele = allele[:-1]
+        elif allele.endswith("g"):
+            if not self.config.strict_enabled:
+                allele = allele[:-1]
+
         if "*" in allele:
             _, fields = allele.split("*")
             if not all(map(str.isalnum, fields.split(":"))):
                 return False
+
         if self._is_allele_in_db(allele):
             return True
         else:
@@ -377,7 +400,7 @@ class ARD(object):
                 if fields in self.config.ignore_allele_with_suffixes:
                     return True
 
-        if not self.config.strict:
+        if not self.config.strict_enabled:
             allele = self._get_non_strict_allele(allele)
 
         if (

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.1.1
+current_version = 2.2.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ script_extras = {"script": ["pandas>=2.0"]}
 
 setup(
     name="py-ard",
-    version="2.1.1",
+    version="2.2.0",
     description="ARD reduction for HLA with Python",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/tests/features/allele.feature
+++ b/tests/features/allele.feature
@@ -59,39 +59,6 @@ Feature: Alleles
       | A*24:329    | lgx   | A*24:329Q    |
       | DQB1*03:276 | lgx   | DQB1*03:01   |
 
-  Scenario Outline: Allele validation in strict mode
-
-    liggle g alleles are valid in non-strict mode
-
-    Given the allele as <Allele>
-    When checking for validity of the allele in strict mode
-    Then the validness of the allele is <Validity>
-
-    Examples:
-      | Allele        | Validity |
-      | A*24:329      | InValid  |
-      | DRBX*NNNN     | Invalid  |
-      | A*30:02g      | Invalid  |
-      | HLA-A*01:04Ng | Invalid  |
-
-  Scenario Outline: Allele validation in non-strict mode
-
-  Similar to reduction, handle non-strict mode when validating an allele.
-  The test version of IPD/IMGT-HLA database (see environment.py),
-  A*11:403 is invalid and A*24:329 is valid for A*24:329Q
-
-    Given the allele as <Allele>
-    When checking for validity of the allele in non-strict mode
-    Then the validness of the allele is <Validity>
-
-    Examples:
-      | Allele        | Validity |
-      | A*11:403      | Invalid  |
-      | A*24:329      | Valid    |
-      | DRBX*NNNN     | Invalid  |
-      | A*30:02g      | Valid    |
-      | HLA-A*01:04Ng | Valid    |
-
   Scenario Outline: Single field MICA, MICB Alleles
 
   For MICA, MICB alleles with single field, their reduced version is self.

--- a/tests/features/p_group.feature
+++ b/tests/features/p_group.feature
@@ -1,6 +1,6 @@
 Feature: P Groups
 
-  Scenario Outline:
+  Scenario Outline: Protein-level reduction in *strict* mode
 
     Given the allele as <Allele>
     When reducing on the <Level> level (ambiguous)
@@ -14,3 +14,13 @@ Feature: P Groups
       | B*07:02:01    | P     | B*07:02P     |
       | B*07:02:01:01 | P     | B*07:02P     |
       | B*15:14       | P     | B*15:14P     |
+
+  Scenario Outline: Protein-level reduction in *non-strict* mode
+
+    Given the allele as <Allele>
+    When reducing on the <Level> level in non-strict mode
+    Then the reduced allele is found to be <Redux Allele>
+
+    Examples:
+      | Allele         | Level | Redux Allele |
+      | DQB1*06:02:02G | P     | DQB1*06:02P  |

--- a/tests/features/valid_allele.feature
+++ b/tests/features/valid_allele.feature
@@ -1,0 +1,108 @@
+Feature: Validate Allele
+
+  Scenario Outline: Valid alleles in strict mode
+
+    Given the allele as <Allele>
+    When checking if the allele is valid in strict mode
+    Then the allele validity is <Validity>
+
+    Examples:
+      | Allele          | Validity |
+      | A*01:01         | Valid    |
+      | A*01:01:01      | Valid    |
+      | A*01:01:01:01   | Valid    |
+      | B*07:02         | Valid    |
+      | C*04:01         | Valid    |
+      | DRB1*03:01      | Valid    |
+      | DQB1*06:02      | Valid    |
+      | A*01:01:01G     | Valid    |
+      | B*07:02:01G     | Valid    |
+      | A*01:01P        | Valid    |
+      | B*07:02P        | Valid    |
+
+  Scenario Outline: Invalid alleles in strict mode
+
+    Given the allele as <Allele>
+    When checking if the allele is valid in strict mode
+    Then the allele validity is <Validity>
+
+    Examples:
+      | Allele          | Validity |
+      | A*99:99         | Invalid  |
+      | Z*01:01         | Invalid  |
+      | A*01:01g        | Invalid  |
+      | A*01:01:99G     | Invalid  |
+
+  Scenario Outline: Valid alleles in non-strict mode
+
+    In non-strict mode, alleles with 'g' suffix are considered valid.
+
+    Given the allele as <Allele>
+    When checking if the allele is valid in non-strict mode
+    Then the allele validity is <Validity>
+
+    Examples:
+      | Allele          | Validity |
+      | A*01:01         | Valid    |
+      | A*01:01:01      | Valid    |
+      | A*01:01g        | Valid    |
+      | B*07:02g        | Valid    |
+      | A*01:01:01G     | Valid    |
+      | A*01:01P        | Valid    |
+
+  Scenario Outline: Invalid alleles in non-strict mode
+
+    Given the allele as <Allele>
+    When checking if the allele is valid in non-strict mode
+    Then the allele validity is <Validity>
+
+    Examples:
+      | Allele          | Validity |
+      | A*99:99         | Invalid  |
+      | Z*01:01         | Invalid  |
+
+  Scenario Outline: Alleles with more than 2 fields fall back to 2-field check
+
+    Given the allele as <Allele>
+    When checking if the allele is valid in strict mode
+    Then the allele validity is <Validity>
+
+    Examples:
+      | Allele            | Validity |
+      | A*01:01:01        | Valid    |
+      | A*01:01:01:01     | Valid    |
+      | A*01:01:99:99     | Valid    |
+      | A*99:99:01:01     | Invalid  |
+
+  Scenario Outline: Allele validation in strict mode
+
+    little g alleles are valid in non-strict mode
+
+    Given the allele as <Allele>
+    When checking for validity of the allele in strict mode
+    Then the validness of the allele is <Validity>
+
+    Examples:
+      | Allele        | Validity |
+      | A*24:329      | InValid  |
+      | DRBX*NNNN     | Invalid  |
+      | A*30:02g      | Invalid  |
+      | HLA-A*01:04Ng | Invalid  |
+
+  Scenario Outline: Allele validation in non-strict mode
+
+  Similar to reduction, handle non-strict mode when validating an allele.
+  The test version of IPD/IMGT-HLA database (see environment.py),
+  A*11:403 is invalid and A*24:329 is valid for A*24:329Q
+
+    Given the allele as <Allele>
+    When checking for validity of the allele in non-strict mode
+    Then the validness of the allele is <Validity>
+
+    Examples:
+      | Allele        | Validity |
+      | A*11:403      | Invalid  |
+      | A*24:329      | Valid    |
+      | DRBX*NNNN     | Invalid  |
+      | A*30:02g      | Valid    |
+      | HLA-A*01:04Ng | Valid    |

--- a/tests/steps/validate_allele.py
+++ b/tests/steps/validate_allele.py
@@ -1,0 +1,39 @@
+#
+#    py-ard
+#    Copyright (c) 2023 Be The Match operated by National Marrow Donor Program. All Rights Reserved.
+#
+#    This library is free software; you can redistribute it and/or modify it
+#    under the terms of the GNU Lesser General Public License as published
+#    by the Free Software Foundation; either version 3 of the License, or (at
+#    your option) any later version.
+#
+#    This library is distributed in the hope that it will be useful, but WITHOUT
+#    ANY WARRANTY; with out even the implied warranty of MERCHANTABILITY or
+#    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+#    License for more details.
+#
+#    You should have received a copy of the GNU Lesser General Public License
+#    along with this library;  if not, write to the Free Software Foundation,
+#    Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA.
+#
+#    > http://www.fsf.org/licensing/licenses/lgpl.html
+#    > http://www.opensource.org/licenses/lgpl-license.php
+#
+from behave import when, then
+from hamcrest import assert_that, is_
+
+
+@when("checking if the allele is valid in strict mode")
+def step_impl(context):
+    context.is_valid_allele = context.ard.is_valid_allele(context.allele)
+
+
+@when("checking if the allele is valid in non-strict mode")
+def step_impl(context):
+    context.is_valid_allele = context.ard_non_strict.is_valid_allele(context.allele)
+
+
+@then("the allele validity is {validity}")
+def step_impl(context, validity):
+    expected = validity == "Valid"
+    assert_that(context.is_valid_allele, is_(expected))


### PR DESCRIPTION
G group validation in `strict` mode (default) requires that the allele be a valid allele and be in WMDA G Group designation.

`strict` mode can be set with passed in `config` parameter.
```python
import pyard
print(pyard.__version__)

strict_ard = pyard.init(config={"strict": True}) # default (same as pyard.init())
not_strict_ard = pyard.init(config={"strict": False})
```

In `strict` mode, `py-ard` requires that the allele be a G group name.
```python
print("strict    :", strict_ard.is_valid_allele("DQB1*06:02:02G"))      # False
print("non-strict:", not_strict_ard.is_valid_allele("DQB1*06:02:02G"))  # True
```

If the allele is a valid G allele (with or without G suffix), `py-ard` will return G-suffixed G group name.
If the allele is not in the G group, it will return without the G suffix as long as the allele is valid
If the alleles is not in the  G group and is G suffixed, py-ard will raise an exception
```python
print("strict:", strict_ard.redux("DQB1*06:02:02", "G"))        # DQB1*06:02:02
print("strict:", strict_ard.redux("DQB1*06:02:02", "G"))        # DQB1*06:02:02
print("strict:", strict_ard.redux("DQB1*06:02", "G"))           # DQB1*06:02:01G
print("strict:", strict_ard.redux("DQB1*06:02:01", "G"))        # DQB1*06:02:01G
print("strict:", strict_ard.redux("DQB1*06:02:01G", "G"))       # DQB1*06:02:01G
try:
    print("strict:", strict_ard.redux("DQB1*06:02:02G", "G"))   # Invalid Allele: DQB1*06:02:02G is not a valid Allele
except pyard.exceptions.InvalidAlleleError as e:
    print(e)
```

In non-strict mode, py-ard will strip off the G suffix if the allele is valid without the suffix
```python
print("non-strict", not_strict_ard.redux("DQB1*06:02:02", "G"))         # DQB1*06:02:02
print("non-strict", not_strict_ard.redux("DQB1*06:02:02G", "G"))        # DQB1*06:02:02
```

In non-strict mode, py-ard behavior is same as in strict-mode for valid G group allele. It will append a `G` if there's none.
```python
print("non-strict:",not_strict_ard.redux("DQB1*06:02:01", "G"))        # DQB1*06:02:01G
print("non-strict:",not_strict_ard.redux("DQB1*06:02:01G", "G"))       # DQB1*06:02:01G
```

In non-strict mode, `lgx` reduction happens without regards to the `G` suffix.
```python
print("lgx: ", not_strict_ard.redux("DQB1*06:02:02G", "lgx"))      # DQB1*06:02
print("lgx: ", not_strict_ard.redux("DQB1*06:02:01G", "lgx"))      # DQB1*06:02
```

Strict mode requires a valid G group allele for G-suffixed alleles.
```python
try:
    print("strict P group:", strict_ard.redux("DQB1*06:02:02G", "P"))        # Invalid Allele: DQB1*06:02:02G is not a valid Allele
except pyard.exceptions.InvalidAlleleError as e:
    print(e)
```

In non-strict mode, `P` reduction occurs at 2 field level.
```python
print("non-strict P group:", not_strict_ard.redux("DQB1*06:02:02", "P"))        # DQB1*06:02P
print("non-strict P group:", not_strict_ard.redux("DQB1*06:02:02G", "P"))       # DQB1*06:02P
```

Fixes #356 