### PR TITLE
feature: Add 1F (First Field) reduction mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ ard.redux('B14', 'lg')
 | `exon`         | Reduce/Expand to 3 field level                            |
 | `U2`           | Reduce to 2 field unambiguous level                       |
 | `S`            | Reduce to Serological level                               |
+| `1F`           | Reduce to First Field level                               |
 
 ### Perform DRB1 blending with DRB3, DRB4 and DRB5
 

--- a/pyard/constants.py
+++ b/pyard/constants.py
@@ -26,7 +26,7 @@ DEFAULT_CACHE_SIZE = 1_000
 
 HLA_regex = re.compile("^HLA-")
 
-VALID_REDUCTION_MODES = ("G", "P", "lg", "lgx", "W", "exon", "U2", "S")
+VALID_REDUCTION_MODES = ("G", "P", "lg", "lgx", "W", "exon", "U2", "S", "1F")
 VALID_REDUCTION_TYPE = typing.Literal[VALID_REDUCTION_MODES]
 
 expression_chars = ("N", "Q", "L", "S")

--- a/pyard/reducers/__init__.py
+++ b/pyard/reducers/__init__.py
@@ -3,6 +3,7 @@
 from .base_reducer import Reducer
 from .default_reducer import DefaultReducer
 from .exon_reducer import ExonReducer
+from .first_field_reducer import FirstFieldReducer
 from .g_reducer import GGroupReducer
 from .lg_reducer import LGReducer, LGXReducer
 from .p_reducer import PGroupReducer
@@ -13,6 +14,7 @@ from .w_reducer import WReducer
 
 __all__ = [
     "Reducer",
+    "FirstFieldReducer",
     "GGroupReducer",
     "PGroupReducer",
     "LGReducer",

--- a/pyard/reducers/first_field_reducer.py
+++ b/pyard/reducers/first_field_reducer.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+from .base_reducer import Reducer
+from ..misc import get_1field_allele
+
+
+class FirstFieldReducer(Reducer):
+    """
+    Strategy for 1F (First Field) reduction of HLA alleles.
+
+    Reduces an allele to its first field only (locus + allele group).
+
+    Examples:
+        - A*01:01:01:01 -> A*01
+        - B*07:02:01    -> B*07
+        - DRB1*15:01    -> DRB1*15
+    """
+
+    def reduce(self, allele: str) -> str:
+        return get_1field_allele(allele)

--- a/pyard/reducers/reducer_factory.py
+++ b/pyard/reducers/reducer_factory.py
@@ -5,6 +5,7 @@ from typing import Dict
 from .base_reducer import Reducer
 from .default_reducer import DefaultReducer
 from .exon_reducer import ExonReducer
+from .first_field_reducer import FirstFieldReducer
 from .g_reducer import GGroupReducer
 from .lg_reducer import LGReducer, LGXReducer
 from .p_reducer import PGroupReducer
@@ -38,6 +39,7 @@ class StrategyFactory:
             "exon": ExonReducer(self.ard),
             "U2": U2Reducer(self.ard),
             "S": SReducer(self.ard),
+            "1F": FirstFieldReducer(self.ard),
             "default": DefaultReducer(self.ard),
         }
 

--- a/tests/features/1f_reduction.feature
+++ b/tests/features/1f_reduction.feature
@@ -1,0 +1,35 @@
+Feature: 1F Reduction
+  Reduction to First Field only
+
+  Reduces any allele to its first field (locus + allele group),
+  discarding all subsequent fields and any expression suffixes.
+
+  Scenario Outline: Reduce to First Field
+
+    Given the allele as <Allele>
+    When reducing on the <Level> level
+    Then the reduced allele is found to be <Redux Allele>
+
+    Examples: Multi-field alleles
+      | Allele            | Level | Redux Allele |
+      | A*01:01:01:01     | 1F    | A*01         |
+      | A*01:01:01        | 1F    | A*01         |
+      | A*01:01           | 1F    | A*01         |
+      | B*07:02:01        | 1F    | B*07         |
+      | C*07:02:01:03     | 1F    | C*07         |
+      | DRB1*15:01:01:01  | 1F    | DRB1*15      |
+      | DQB1*06:02:01     | 1F    | DQB1*06      |
+      | DPB1*04:01:01:01  | 1F    | DPB1*04      |
+
+    Examples: Alleles with expression suffixes
+      | Allele            | Level | Redux Allele |
+      | A*01:04:01:01N    | 1F    | A*01         |
+      | B*56:01:01:05S    | 1F    | B*56         |
+      | B*39:01:01:02L    | 1F    | B*39         |
+      | DRB5*01:08:01N    | 1F    | DRB5*01      |
+
+    Examples: HLA-prefixed alleles
+      | Allele            | Level | Redux Allele |
+      | HLA-A*01:01:01    | 1F    | HLA-A*01     |
+      | HLA-B*07:02:01    | 1F    | HLA-B*07     |
+      | HLA-DRB1*15:01:01 | 1F    | HLA-DRB1*15  |

--- a/tests/unit/reducers/test_first_field_reducer.py
+++ b/tests/unit/reducers/test_first_field_reducer.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+from unittest.mock import Mock, patch
+from pyard.reducers.first_field_reducer import FirstFieldReducer
+
+
+@pytest.fixture
+def mock_ard():
+    return Mock()
+
+
+@pytest.mark.parametrize(
+    "allele, expected",
+    [
+        ("A*01:01:01:01", "A*01"),
+        ("B*07:02:01", "B*07"),
+        ("DRB1*15:01:01", "DRB1*15"),
+        ("A*01:01", "A*01"),
+        ("A*01", "A*01"),
+        ("C*07:02:01:03", "C*07"),
+    ],
+)
+def test_reduce(mock_ard, allele, expected):
+    assert FirstFieldReducer(mock_ard).reduce(allele) == expected
+
+
+def test_reduce_calls_get_1field_allele(mock_ard):
+    with patch(
+        "pyard.reducers.first_field_reducer.get_1field_allele", return_value="A*01"
+    ) as mock_fn:
+        FirstFieldReducer(mock_ard).reduce("A*01:01:01:01")
+        mock_fn.assert_called_once_with("A*01:01:01:01")

--- a/tests/unit/reducers/test_reducer_factory.py
+++ b/tests/unit/reducers/test_reducer_factory.py
@@ -10,6 +10,7 @@ from pyard.reducers.w_reducer import WReducer
 from pyard.reducers.exon_reducer import ExonReducer
 from pyard.reducers.u2_reducer import U2Reducer
 from pyard.reducers.s_reducer import SReducer
+from pyard.reducers.first_field_reducer import FirstFieldReducer
 from pyard.reducers.default_reducer import DefaultReducer
 
 
@@ -24,7 +25,7 @@ def test_strategy_factory_initialization(mock_ard):
     factory = StrategyFactory(mock_ard)
 
     assert factory.ard == mock_ard
-    assert len(factory._strategies) == 9
+    assert len(factory._strategies) == 10
 
 
 def test_get_g_strategy(mock_ard):
@@ -89,6 +90,14 @@ def test_get_s_strategy(mock_ard):
     strategy = factory.get_strategy("S")
 
     assert isinstance(strategy, SReducer)
+
+
+def test_get_1f_strategy(mock_ard):
+    """Test getting 1F strategy"""
+    factory = StrategyFactory(mock_ard)
+    strategy = factory.get_strategy("1F")
+
+    assert isinstance(strategy, FirstFieldReducer)
 
 
 def test_get_default_strategy(mock_ard):


### PR DESCRIPTION
Add a new `1F` redux mode that reduces any HLA allele to its first field (locus + allele group) only, e.g. `A*01:01:01:01` -> `A*01`.

Changes:
- `pyard/constants.py`: Add `1F` to `VALID_REDUCTION_MODES`
- `pyard/reducers/first_field_reducer.py`: New `FirstFieldReducer` class, delegates to the existing `get_1field_allele()` helper in `misc.py`
- `pyard/reducers/__init__.py`: Export FirstFieldReducer
- `pyard/reducers/reducer_factory.py`: Register '1F' -> FirstFieldReducer in StrategyFactory
- `tests/unit/reducers/test_first_field_reducer.py`: New pytest unit tests (parametrized reduce cases + mock delegation check)
- `tests/unit/reducers/test_reducer_factory.py`: Add 1F strategy test, update strategy count 9 -> 10
- `tests/features/1f_reduction.feature`: New BDD feature file with 15 scenarios covering multi-field alleles, expression suffixes (N/S/L), and HLA-prefixed alleles

```
>>> import pyard
>>> ard = pyard.init()
>>> ard.redux("A*01:01:01:02N", "1F")
'A*01'
>>> 
```


Fixes #327 