### PR TITLE
feature:  🎩 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,10 +81,10 @@ celerybeat-schedule
 
 # dotenv
 .env
+.env.dev
 
 # virtualenv
-.venv
-venv/
+.?venv*/
 ENV/
 
 # Spyder project settings
@@ -112,8 +112,15 @@ allure_report/
 
 # Misc
 tags
-.swp
+*.swp
 *.patch
 .direnv/
 .envrc
 .idea/
+tmp/
+temp/
+demo/
+great-docs/
+.vscode
+__marimo__
+.DS_Store

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -65,6 +65,8 @@ graph TB
         U2[U2Reducer]
         S[SReducer]
         EXON[ExonReducer]
+        1F[FirstFieldReducer]
+        HATS[HATSReducer]
     end
 
     subgraph "Data Layer"
@@ -93,6 +95,8 @@ graph TB
     FACTORY --> U2
     FACTORY --> S
     FACTORY --> EXON
+    FACTORY --> 1F
+    FACTORY --> HATS
 
     ARD --> DR
     DR --> DB
@@ -311,6 +315,14 @@ classDiagram
         +reduce(allele: str) str
     }
 
+    class FirstFieldReducer {
+        +reduce(allele: str) str
+    }
+
+    class HATSReducer {
+        +reduce(allele: str) str
+    }
+
     Reducer <|-- GGroupReducer
     Reducer <|-- PGroupReducer
     Reducer <|-- LGReducer
@@ -319,6 +331,8 @@ classDiagram
     Reducer <|-- U2Reducer
     Reducer <|-- SReducer
     Reducer <|-- ExonReducer
+    Reducer <|-- FirstFieldReducer
+    Reducer <|-- HATSReducer
 ```
 
 **Reducer Types:**
@@ -455,9 +469,11 @@ erDiagram
         string locus
     }
 
-    ALLELES ||--o{ G_GROUP : "maps to"
-    ALLELES ||--o{ P_GROUP : "maps to"
-    ALLELES ||--o{ LGX_GROUP : "maps to"
+    ANTIGEN_SPECIFITIES {
+        string allele PK
+        string TEXT
+    }
+
 ```
 
 ---

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL MAINTAINER="Pradeep Bashyal"
 
 WORKDIR /app
 
-ARG PY_ARD_VERSION=2.2.1
+ARG PY_ARD_VERSION=2.3.0
 
 COPY requirements.txt /app
 RUN pip install --no-cache-dir --upgrade pip && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL MAINTAINER="Pradeep Bashyal"
 
 WORKDIR /app
 
-ARG PY_ARD_VERSION=2.2.0
+ARG PY_ARD_VERSION=2.2.1
 
 COPY requirements.txt /app
 RUN pip install --no-cache-dir --upgrade pip && \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT_NAME := $(shell basename `pwd`)
 PACKAGE_NAME := pyard
-PYARD_VERSION := 2.2.0
+PYARD_VERSION := 2.2.1
 
 .PHONY: help clean clean-test clean-pyc clean-build docs behave lint pytest test coverage docs servedocs release dist docker-build docker install venv activate
 .DEFAULT_GOAL := help

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT_NAME := $(shell basename `pwd`)
 PACKAGE_NAME := pyard
-PYARD_VERSION := 2.2.1
+PYARD_VERSION := 2.3.0
 
 .PHONY: help clean clean-test clean-pyc clean-build docs behave lint pytest test coverage docs servedocs release dist docker-build docker install venv activate
 .DEFAULT_GOAL := help

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ ard.redux('B14', 'lg')
 | `U2`           | Reduce to 2 field unambiguous level                       |
 | `S`            | Reduce to Serological level                               |
 | `1F`           | Reduce to First Field level                               |
+| `hats`         | Reduce to Antigen Specificity using HATS strategy         |
 
 ### Perform DRB1 blending with DRB3, DRB4 and DRB5
 

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -7,7 +7,7 @@ info:
     based on IPD-IMGT/HLA allele data.
 
     See [py-ard.org](https://py-ard.org) for full documentation.
-  version: "2.2.0"
+  version: "2.2.1"
   license:
     name: LGPL-3
     url: https://www.gnu.org/licenses/lgpl-3.0.html

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -7,7 +7,7 @@ info:
     based on IPD-IMGT/HLA allele data.
 
     See [py-ard.org](https://py-ard.org) for full documentation.
-  version: "2.2.1"
+  version: "2.3.0"
   license:
     name: LGPL-3
     url: https://www.gnu.org/licenses/lgpl-3.0.html

--- a/pyard/__init__.py
+++ b/pyard/__init__.py
@@ -28,7 +28,7 @@ from .constants import DEFAULT_CACHE_SIZE
 from .misc import get_imgt_db_versions as db_versions
 
 __author__ = """NMDP Bioinformatics"""
-__version__ = "2.2.0"
+__version__ = "2.2.1"
 
 
 def init(

--- a/pyard/__init__.py
+++ b/pyard/__init__.py
@@ -28,7 +28,7 @@ from .constants import DEFAULT_CACHE_SIZE
 from .misc import get_imgt_db_versions as db_versions
 
 __author__ = """NMDP Bioinformatics"""
-__version__ = "2.2.1"
+__version__ = "2.3.0"
 
 
 def init(

--- a/pyard/constants.py
+++ b/pyard/constants.py
@@ -26,7 +26,7 @@ DEFAULT_CACHE_SIZE = 1_000
 
 HLA_regex = re.compile("^HLA-")
 
-VALID_REDUCTION_MODES = ("G", "P", "lg", "lgx", "W", "exon", "U2", "S", "1F")
+VALID_REDUCTION_MODES = ("G", "P", "lg", "lgx", "W", "exon", "U2", "S", "1F", "hats")
 VALID_REDUCTION_TYPE = typing.Literal[VALID_REDUCTION_MODES]
 
 expression_chars = ("N", "Q", "L", "S")

--- a/pyard/data_repository.py
+++ b/pyard/data_repository.py
@@ -370,16 +370,47 @@ def to_serological_name(locus_name: str):
     return sero_name
 
 
+def _generate_antigen_specifities(db_connection, serology_mapping_df):
+    """
+    Generate and persist HATS (HLA Antigen Typing Specificities) mappings.
+
+    For each allele in the serology mapping that has a HATS value, creates
+    mappings from all field-level representations (1F, 2F, 3F, and full allele)
+    to their HATS antigen specificity, then saves them to the database.
+
+    Only called for IPD-IMGT/HLA version >= 3.64.0, which introduced the HATS column.
+
+    :param db_connection: Active SQLite database connection
+    :param serology_mapping_df: Table containing serology data with a 'Locus*Allele'
+        column and a 'HATS' column
+    """
+    hats_df = serology_mapping_df.where_not_null("HATS")[["Locus*Allele", "HATS"]]
+    hats_df.rename({"Locus*Allele": "Allele"})
+    hats_df["1F"] = hats_df["Allele"].apply(get_1field_allele)
+    hats_df["2F"] = hats_df["Allele"].apply(get_2field_allele)
+    hats_df["3F"] = hats_df["Allele"].apply(get_3field_allele)
+    hats_final = (
+        hats_df[["Allele", "HATS"]]
+        .union(hats_df[["1F", "HATS"]].rename({"1F": "Allele"}))
+        .union(hats_df[["2F", "HATS"]].rename({"2F": "Allele"}))
+        .union(hats_df[["3F", "HATS"]].rename({"3F": "Allele"}))
+    )
+    db.save_antigen_specifities(db_connection, hats_final.to_dict())
+
+
 def generate_serology_mapping(
     db_connection: sqlite3.Connection,
     imgt_version: str,
     serology_mapping: SerologyMapping,
     redux_function,
 ):
-    if not db.table_exists(db_connection, "serology_mapping"):
+    if not db.tables_exist(db_connection, ["serology_mapping", "antigen_specifities"]):
         df_sero = load_serology_mappings(imgt_version)
-
         df_sero["Locus*Allele"] = df_sero.concat_columns(["Locus", "Allele"])
+
+        # Only valid for Version >= IPD-IMGT/HLA 3.64.0
+        if "HATS" in df_sero.columns:
+            _generate_antigen_specifities(db_connection, df_sero)
 
         # Remove 0 and ? from USA
         usa = df_sero.where("USA is not null and USA not in ('0', '?')")

--- a/pyard/db.py
+++ b/pyard/db.py
@@ -436,7 +436,7 @@ def find_hats(connection: sqlite3.Connection, allele: str) -> str:
     :param allele: allele for which to find the HATS
     :return: HATS value for the given allele, or None if not found
     """
-    query = "SELECT hat FROM antigen_specifities WHERE allele = ?"
+    query = "SELECT hats FROM antigen_specifities WHERE allele = ?"
     cursor = connection.execute(query, (allele,))
     result = cursor.fetchone()
     cursor.close()
@@ -598,7 +598,7 @@ def save_antigen_specifities(db_connection, hats_dict):
         db_connection,
         table_name="antigen_specifities",
         dictionary=hats_dict,
-        columns=("allele", "hat"),
+        columns=("allele", "hats"),
     )
 
 

--- a/pyard/db.py
+++ b/pyard/db.py
@@ -428,6 +428,23 @@ def find_xx_for_serology(connection: sqlite3.Connection, serology: str) -> str:
     return None
 
 
+def find_hats(connection: sqlite3.Connection, allele: str) -> str:
+    """
+    Find the corresponding HATS (HLA Antigen Typing Specificity) for the given allele.
+
+    :param connection: db connection of type sqlite.Connection
+    :param allele: allele for which to find the HATS
+    :return: HATS value for the given allele, or None if not found
+    """
+    query = "SELECT hat FROM antigen_specifities WHERE allele = ?"
+    cursor = connection.execute(query, (allele,))
+    result = cursor.fetchone()
+    cursor.close()
+    if result:
+        return result[0]
+    return None
+
+
 def get_user_version(connection: sqlite3.Connection) -> int:
     """
     Retrieve user_version from db
@@ -572,6 +589,16 @@ def save_mac_codes(db_connection, mac, mac_table_name):
         table_name=mac_table_name,
         dictionary=mac,
         columns=("code", "alleles"),
+    )
+
+
+def save_antigen_specifities(db_connection, hats_dict):
+    # Save the antigen specifities built with HATS algorithm to db
+    save_dict(
+        db_connection,
+        table_name="antigen_specifities",
+        dictionary=hats_dict,
+        columns=("allele", "hat"),
     )
 
 

--- a/pyard/reducers/__init__.py
+++ b/pyard/reducers/__init__.py
@@ -8,6 +8,7 @@ from .g_reducer import GGroupReducer
 from .lg_reducer import LGReducer, LGXReducer
 from .p_reducer import PGroupReducer
 from .reducer_factory import StrategyFactory
+from .hats_reducer import HATSReducer
 from .s_reducer import SReducer
 from .u2_reducer import U2Reducer
 from .w_reducer import WReducer
@@ -23,6 +24,7 @@ __all__ = [
     "ExonReducer",
     "U2Reducer",
     "SReducer",
+    "HATSReducer",
     "DefaultReducer",
     "StrategyFactory",
 ]

--- a/pyard/reducers/hats_reducer.py
+++ b/pyard/reducers/hats_reducer.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+from .base_reducer import Reducer
+from .. import db
+
+
+class HATSReducer(Reducer):
+    """
+    Strategy for HATS (HLA Antigen Typing Specificity) reduction of HLA alleles.
+
+    Reduces an allele to its HATS value by looking up the antigen_specifities
+    table. Only available for IPD-IMGT/HLA version >= 3.64.0.
+
+    If no HATS value is found (e.g. the allele is not in the table, or the
+    database predates 3.64.0), an empty string is returned
+
+    Examples:
+        - A*01:01:01:01 -> A1   (mapped)
+        - A*01:01       -> A1   (mapped)
+        - B*44:450      -> 4402 (mapped)
+        - B*44:458      -> ''   (not mapped)
+    """
+
+    def reduce(self, allele: str) -> str:
+        result = db.find_hats(self.ard.db_connection, allele)
+        return result if result is not None else ""

--- a/pyard/reducers/hats_reducer.py
+++ b/pyard/reducers/hats_reducer.py
@@ -15,12 +15,31 @@ class HATSReducer(Reducer):
     database predates 3.64.0), an empty string is returned
 
     Examples:
-        - A*01:01:01:01 -> A1   (mapped)
-        - A*01:01       -> A1   (mapped)
-        - B*44:450      -> 4402 (mapped)
-        - B*44:458      -> ''   (not mapped)
+        - A*01:01:01:01 -> A1     (mapped)
+        - A*01:01       -> A1     (mapped)
+        - B*44:450      -> B4402  (mapped)
+        - B*35:570      -> Cw0408 (mapped)
+        - B*44:458      -> ''     (not mapped)
     """
 
     def reduce(self, allele: str) -> str:
         result = db.find_hats(self.ard.db_connection, allele)
-        return result if result is not None else ""
+        if result:
+            locus, _ = allele.split("*")
+            # For those that already have an assigned locus e.g. Cw0408
+            if result[0].isalpha():
+                return result
+            if locus == "C":
+                return f"Cw{result}"
+            if locus in ("DRB1", "DRB3", "DRB4", "DRB5"):
+                return f"DR{result}"
+            if locus in ("DQA1", "DQA2"):
+                return f"DQA{result}"
+            if locus in ("DQB1", "DQB2"):
+                return f"DQ{result}"
+            if locus in ("DPA1", "DPA2"):
+                return f"DPA{result}"
+            if locus in ("DPB1", "DPB2"):
+                return f"DPB{result}"
+            return f"{locus}{result}"
+        return ""

--- a/pyard/reducers/reducer_factory.py
+++ b/pyard/reducers/reducer_factory.py
@@ -7,6 +7,7 @@ from .default_reducer import DefaultReducer
 from .exon_reducer import ExonReducer
 from .first_field_reducer import FirstFieldReducer
 from .g_reducer import GGroupReducer
+from .hats_reducer import HATSReducer
 from .lg_reducer import LGReducer, LGXReducer
 from .p_reducer import PGroupReducer
 from .s_reducer import SReducer
@@ -40,6 +41,7 @@ class StrategyFactory:
             "U2": U2Reducer(self.ard),
             "S": SReducer(self.ard),
             "1F": FirstFieldReducer(self.ard),
+            "hats": HATSReducer(self.ard),
             "default": DefaultReducer(self.ard),
         }
 

--- a/pyard/smart_sort.py
+++ b/pyard/smart_sort.py
@@ -102,6 +102,8 @@ def smart_sort_comparator(a1, a2, ignore_suffixes=()):
     # Handle serological designations (no colon separator)
     # Compare numeric parts of serology (e.g., '27' in 'B27')
     if ":" not in a1:
+        if a1.isdigit() and a2.isdigit():
+            return 1 if int(a1) > int(a2) else -1
         serology1_match = serology_splitter.match(a1)
         serology1_num = int(serology1_match.group(2))  # Extract numeric part
         serology2_match = serology_splitter.match(a2)

--- a/pyard/smart_sort.py
+++ b/pyard/smart_sort.py
@@ -99,11 +99,17 @@ def smart_sort_comparator(a1, a2, ignore_suffixes=()):
     if a1 == a2:
         return 0
 
-    # Handle serological designations (no colon separator)
-    # Compare numeric parts of serology (e.g., '27' in 'B27')
+    # Handle Serology and HATS
     if ":" not in a1:
+        # HATS are mostly numerical, so compare as integers
         if a1.isdigit() and a2.isdigit():
             return 1 if int(a1) > int(a2) else -1
+        # For HATS with mixed alphanumeric strings, sort lexicographically
+        # e.g. Cw0304, Cw0408
+        if a1.isdigit() or a2.isdigit():
+            return a1 < a2
+        # Handle serological designations (no colon separator)
+        # Compare numeric parts of serology (e.g., '27' in 'B27')
         serology1_match = serology_splitter.match(a1)
         serology1_num = int(serology1_match.group(2))  # Extract numeric part
         serology2_match = serology_splitter.match(a2)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.2.0
+current_version = 2.2.1
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.2.1
+current_version = 2.3.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ script_extras = {"script": ["pandas>=2.0"]}
 
 setup(
     name="py-ard",
-    version="2.2.1",
+    version="2.3.0",
     description="ARD reduction for HLA with Python",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ script_extras = {"script": ["pandas>=2.0"]}
 
 setup(
     name="py-ard",
-    version="2.2.0",
+    version="2.2.1",
     description="ARD reduction for HLA with Python",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/tests/unit/reducers/test_reducer_factory.py
+++ b/tests/unit/reducers/test_reducer_factory.py
@@ -25,7 +25,7 @@ def test_strategy_factory_initialization(mock_ard):
     factory = StrategyFactory(mock_ard)
 
     assert factory.ard == mock_ard
-    assert len(factory._strategies) == 10
+    assert len(factory._strategies) == 11
 
 
 def test_get_g_strategy(mock_ard):


### PR DESCRIPTION
## `hats`  redux mode
 Reduce to Antigen Specificity using HATS strategy     

- create a new table `antigen_specifities` that maps all alleles + 1F + 2F and 3F versions to their corresponding HATS based on `rel_dna_ser` file
- Add HATSReducer that looks up HATS from antigen_specifities table via db.find_hats(),
- Add find_hats() to db.py to query antigen_specifities table
- Bump version: 2.2.0 → 2.3.0

Note: HATS reduction only returns results for IPD-IMGT/HLA >= 3.64.0

Fixes #330 

Code:
```
>>> import pyard
>>> ard = pyard.init()
>>> ard.redux("B*44:450", "hats")
'4402'
>>> 
```

CLI:
```
❯ pyard -g "B*44:450" -r hats
4402
❯ pyard -g "B*44:458" -r hats

```