### PR TITLE
Fix undefined data_dir reference in pyard-import error message

### DIFF
--- a/scripts/pyard-import
+++ b/scripts/pyard-import
@@ -47,7 +47,7 @@ def get_v2_v3_mapping(v2_v3_mapping):
 
         path = pathlib.Path(v2_v3_mapping)
         if not path.exists() or not path.is_file():
-            raise RuntimeError(f"{data_dir} is not a valid file")
+            raise RuntimeError(f"{path} is not a valid file")
         df = pd.read_csv(path, names=["v2", "v3"])
         return df.set_index("v2")["v3"].to_dict()
     return None

--- a/tests/unit/test_pyard_import_script.py
+++ b/tests/unit/test_pyard_import_script.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+import importlib.util
+import pathlib
+import sys
+from importlib.machinery import SourceFileLoader
+from unittest.mock import Mock
+
+import pytest
+
+SCRIPT_PATH = pathlib.Path(__file__).parents[2] / "scripts" / "pyard-import"
+
+
+@pytest.fixture
+def pyard_import(monkeypatch):
+    """Load the extensionless `pyard-import` script as an importable module.
+
+    `pandas` is only used to read the mapping CSV and is an optional extra,
+    so it's stubbed out to keep these tests runnable without it installed.
+    """
+    monkeypatch.setitem(sys.modules, "pandas", Mock())
+    loader = SourceFileLoader("pyard_import_script", str(SCRIPT_PATH))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+def test_missing_mapping_file_error_names_the_mapping_file(pyard_import, tmp_path):
+    missing_file = tmp_path / "missing-mapping.csv"
+
+    with pytest.raises(RuntimeError) as exc_info:
+        pyard_import.get_v2_v3_mapping(str(missing_file))
+
+    assert str(missing_file) in str(exc_info.value)
+
+
+def test_directory_as_mapping_file_error_names_the_directory(pyard_import, tmp_path):
+    with pytest.raises(RuntimeError) as exc_info:
+        pyard_import.get_v2_v3_mapping(str(tmp_path))
+
+    assert str(tmp_path) in str(exc_info.value)
+
+
+def test_no_mapping_file_returns_none(pyard_import):
+    assert pyard_import.get_v2_v3_mapping(None) is None


### PR DESCRIPTION
`get_v2_v3_mapping` validates `path` but interpolates `data_dir`, which isn't defined in the function. Run from the CLI it resolves to the module-level global and names the data directory instead of the mapping file that failed; called any other way it raises `NameError` and masks the real error.

```
$ pyard-import --v2-to-v3-mapping /tmp/pyard-repro/missing-mapping.csv -d /tmp/pyard-repro
RuntimeError: /tmp/pyard-repro is not a valid file   # names the data dir, not the .csv
```

Changes:
- `scripts/pyard-import`: Report `path`, the file that actually failed validation
- `tests/unit/test_pyard_import_script.py`: New pytest unit tests covering both error paths and the no-mapping-file passthrough. The script is extensionless, so it's loaded with `SourceFileLoader`, and `pandas` is stubbed through `sys.modules` since it's only in the `script` extra and isn't installed in CI.

Fixes #394
