### PR TITLE
Expand MAC based on common HATS assignments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL MAINTAINER="Pradeep Bashyal"
 
 WORKDIR /app
 
-ARG PY_ARD_VERSION=2.3.0
+ARG PY_ARD_VERSION=2.3.1
 
 COPY requirements.txt /app
 RUN pip install --no-cache-dir --upgrade pip && \

--- a/Dockerfile-local
+++ b/Dockerfile-local
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bullseye
+FROM python:3.14-slim-trixie
 
 LABEL MAINTAINER="Pradeep Bashyal"
 
@@ -11,9 +11,11 @@ RUN pip install --no-cache-dir --upgrade pip && \
 COPY requirements-deploy.txt /app
 RUN pip install --no-cache-dir -r requirements-deploy.txt
 
+COPY pyard /app/pyard
+
 COPY app.py /app/
 COPY api.py /app/
 COPY api-spec.yaml /app/
-COPY pyard /app/pyard
+COPY gunicorn_config.py /app/
 
-CMD ["gunicorn", "--bind", "0.0.0.0:8080", "--worker-tmp-dir", "/dev/shm",  "--timeout", "30", "app:app"]
+CMD ["gunicorn", "-c", "gunicorn_config.py", "--workers=4", "app:app"]

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,10 @@ docker-build: ## build a docker image for the service
 docker: docker-build ## build a docker image and run the service
 	docker run --platform=linux/amd64 --rm --name pyard-service -p 8080:8080 nmdpbioinformatics/pyard-service:$(PYARD_VERSION).linux-amd64
 
+docker-build-local: ## build a local docker image for the service
+	docker build --platform=linux/amd64 -t nmdpbioinformatics/pyard-service:$(PYARD_VERSION).linux-amd64 -f Dockerfile-local .
+	docker run --platform=linux/amd64 --rm --name pyard-service -p 8080:8080 nmdpbioinformatics/pyard-service:$(PYARD_VERSION).linux-amd64
+
 install: clean ## install the package to the active Python's site-packages
 	pip install --upgrade pip
 	pip install -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT_NAME := $(shell basename `pwd`)
 PACKAGE_NAME := pyard
-PYARD_VERSION := 2.3.0
+PYARD_VERSION := 2.3.1
 
 .PHONY: help clean clean-test clean-pyc clean-build docs behave lint pytest test coverage docs servedocs release dist docker-build docker install venv activate
 .DEFAULT_GOAL := help

--- a/README.md
+++ b/README.md
@@ -289,6 +289,15 @@ ard.lookup_mac(ard.cwd_redux("B*15:01:01/B*15:01:03/B*15:04/B*15:07/B*15:26N/B*1
 # 'B*15:AH'
 ```
 
+### HATS reduction mode
+
+Reduce to Antigen Specificity using HATS strategy
+
+```python
+ard.redux("B*44:450", "hats")
+# => '4402'
+```
+
 ### Additional Methods
 
 Validate a GL String:
@@ -539,6 +548,9 @@ DRB1*08:01:01G/DRB1*08:02:01G/DRB1*08:03:02G/DRB1*08:04:01G/DRB1*08:05/ ...
 
 $ pyard -i 3290 --gl 'A1' -r lgx # For a particular version of DB
 A*01:01/A*01:02/A*01:03/A*01:06/A*01:07/A*01:08/A*01:09/A*01:10/A*01:12/ ...
+
+$ pyard -g "B*44:450" -r hats
+4402
 ```
 
 If the `-r` option is left out, `pyard` will print out the result of all reduction methods.
@@ -606,6 +618,11 @@ A*01:01/A*01:02
 $ pyard --expand-xx 'A*01:XX'
 A*01:01/A*01:02/A*01:03/...
 ```
+Expand MAC based on HATS assignment for expanded alleles
+
+```shell
+$ pyard --expand-mac-hats "A*24:ABWMU"
+````
 
 Lookup MAC code:
 

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -48,6 +48,9 @@ components:
           type: array
           items:
             type: string
+          example:
+            - "HLA-A*01:01"
+            - "HLA-A*01:02"
 tags:
   - name: ARD Reduction
     description: Reduce GL String to ARD
@@ -294,6 +297,53 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /mac-hats/{allele_code}:
+    get:
+      tags:
+        - MAC
+      operationId: api.mac_hats_expand_controller
+      summary: Expand MAC (Allele Code) based on HATS assignment
+      description: |
+        Given a MAC Code, find all alleles based on HATS assignment
+      parameters:
+        - name: allele_code
+          in: path
+          description: A valid MAC (Allele Code)
+          required: true
+          schema:
+            type: string
+            example: "HLA-A*01:AB"
+      responses:
+        200:
+          description: Alleles corresponding to MAC
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  mac:
+                    description: MAC
+                    type: string
+                    example: "HLA-A*01:AB"
+                  gl_string:
+                    description: GL String version of expanded MAC
+                    type: string
+                    example: "A*01:01/A*01:02/A*01:03/A*01:06/A*01:09/A*01:10"
+                  alleles:
+                    $ref: '#/components/schemas/AlleleList/properties/alleles'
+                    example:
+                      - "A*01:01"
+                      - "A*01:02"
+                      - "A*01:03"
+                      - "A*01:06"
+                      - "A*01:09"
+                      - "A*01:10"
+        400:
+          description: Invalid MAC Code
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /xx/{xx_code}:
     get:
       tags:
@@ -378,6 +428,7 @@ paths:
                     example: "HLA-A*01:01/HLA-A*01:02"
                   alleles:
                     $ref: '#/components/schemas/AlleleList/properties/alleles'
+
         400:
           description: Invalid MAC Code
           content:

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -7,7 +7,7 @@ info:
     based on IPD-IMGT/HLA allele data.
 
     See [py-ard.org](https://py-ard.org) for full documentation.
-  version: "2.3.0"
+  version: "2.3.1"
   license:
     name: LGPL-3
     url: https://www.gnu.org/licenses/lgpl-3.0.html

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -36,7 +36,7 @@ components:
         pyard_version:
           description: py-ard library version
           type: string
-          example: "1.5.0"
+          example: "2.3.1"
     AlleleList:
       type: object
       properties:
@@ -79,11 +79,16 @@ paths:
         Get IPD-IMGT/HLA DB Version and `py-ard` version used for this service
       responses:
         200:
-          description: IPD-IMGT/HLA version number
+          description: |
+            IPD-IMGT/HLA version number and py-ard version number
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/VersionInfo'
+            text/plain:
+              schema:
+                type: string
+                example: "3560/2.3.1"
         500:
           description: Unexpected server error
           content:
@@ -110,6 +115,8 @@ paths:
         | `exon`         | Reduce/Expand to 3 field level                            |
         | `U2`           | Reduce to 2 field unambiguous level                       |
         | `S`            | Reduce to Serological level                               |
+        | `1F`           | Reduce to First Field level                               |
+        | `hats`         | Reduce to Antigen Specificity using HATS strategy         |
 
       requestBody:
         content:
@@ -136,6 +143,8 @@ paths:
                     - exon
                     - U2
                     - S
+                    - 1F
+                    - hats
                   example: "lgx"
       responses:
         200:
@@ -167,7 +176,7 @@ paths:
     get:
       tags:
         - ARD Reduction
-      operationId: api.lgx_controller
+      operationId: api.ard_controller
       summary: Reduce to ARD
       description: |
         Get ARD Reduction for an Allele
@@ -203,7 +212,10 @@ paths:
                     description: py-ard library version
                     type: string
                     example: "1.2.1"
-
+            text/plain:
+              schema:
+                type: string
+                example: "DPA1*02:02"
         400:
           description: Invalid Allele
           content:
@@ -291,6 +303,10 @@ paths:
                     example: "HLA-A*01:01/HLA-A*01:02"
                   alleles:
                     $ref: '#/components/schemas/AlleleList/properties/alleles'
+            text/plain:
+              schema:
+                type: string
+                example: "HLA-A*01:01/HLA-A*01:02"
         400:
           description: Invalid MAC Code
           content:
@@ -331,13 +347,10 @@ paths:
                     example: "A*01:01/A*01:02/A*01:03/A*01:06/A*01:09/A*01:10"
                   alleles:
                     $ref: '#/components/schemas/AlleleList/properties/alleles'
-                    example:
-                      - "A*01:01"
-                      - "A*01:02"
-                      - "A*01:03"
-                      - "A*01:06"
-                      - "A*01:09"
-                      - "A*01:10"
+            text/plain:
+              schema:
+                type: string
+                example: "A*01:01/A*01:02/A*01:03/A*01:06/A*01:09/A*01:10"
         400:
           description: Invalid MAC Code
           content:
@@ -384,6 +397,11 @@ paths:
                     example:
                       - "HLA-A*43:01"
                       - "HLA-A*43:02N"
+            text/plain:
+              schema:
+                type: string
+                example: "HLA-A*43:01/HLA-A*43:02N"
+
         400:
           description: Invalid XX Code
           content:
@@ -496,7 +514,7 @@ paths:
     get:
       tags:
         - Validation
-      operationId: api.validate_controller_get
+      operationId: api.valid_controller
       summary: Validate GL String
       description: |
         Given a GL String report whether it is valid or not
@@ -516,9 +534,14 @@ paths:
                 type: object
                 properties:
                   valid:
-                    description: Is GL String valid
+                    description: GL String is valid
                     type: boolean
                     example: true
+            text/plain:
+              schema:
+                description: GL String is valid
+                type: string
+                example: "true"
         404:
           description: GL String didn't validate
           content:
@@ -538,6 +561,11 @@ paths:
                     description: Explanation of why the GL String is not valid
                     type: string
                     example: "HLA-A*01:BLAH is not a valid GL Allele"
+            text/plain:
+              schema:
+                description: GL String is not valid
+                type: string
+                example: "false"
         400:
           description: Invalid GL String Form
           content:

--- a/api.py
+++ b/api.py
@@ -1,5 +1,3 @@
-import connexion
-
 import pyard
 from pyard.blender import DRBXBlenderError
 from pyard.exceptions import PyArdError, InvalidAlleleError
@@ -80,7 +78,7 @@ def lgx_controller(allele):
         except PyArdError as e:
             return {"message": e.message}, 400
     else:
-        return {"message": f"No allele provided"}, 404
+        return {"message": "No allele provided"}, 404
 
 
 def xx_expand_controller(xx_code: str):
@@ -102,6 +100,21 @@ def mac_expand_controller(allele_code: str):
     try:
         if ard.is_mac(allele_code):
             allele_list = ard.expand_mac(allele_code)
+            return {
+                "mac": allele_code,
+                "alleles": allele_list.split("/"),
+                "gl_string": allele_list,
+            }, 200
+        else:
+            return {"message": f"{allele_code} is not a valid MAC"}, 404
+    except PyArdError as e:
+        return {"message": e.message}, 400
+
+
+def mac_hats_expand_controller(allele_code: str):
+    try:
+        if ard.is_mac(allele_code):
+            allele_list = ard.expand_mac_to_hats_alleles(allele_code)
             return {
                 "mac": allele_code,
                 "alleles": allele_list.split("/"),

--- a/api.py
+++ b/api.py
@@ -1,3 +1,4 @@
+from flask import request
 import pyard
 from pyard.blender import DRBXBlenderError
 from pyard.exceptions import PyArdError, InvalidAlleleError
@@ -18,24 +19,34 @@ def validate_controller(body):
         try:
             gl_string = body["gl_string"]
         except KeyError:
-            return {"message": "gl_string not provided"}, 404
+            return {"message": "gl_string not provided"}, 400
         return validate_gl(gl_string)
 
 
-def validate_controller_get(gl_string: str):
+def valid_controller(gl_string: str):
     return validate_gl(gl_string)
 
 
 def validate_gl(gl_string):
     try:
         ard.validate(gl_string)
-        return "Yes", 200
+        if request.accept_mimetypes.best == "application/json":
+            return {"valid": True}, 200, {"Content-Type": "application/json"}
+        else:
+            return "true", 200, {"Content-Type": "text/plain"}
     except InvalidAlleleError as e:
-        return {
-            "valid": False,
-            "message": f"Provided GL String is invalid: {gl_string}",
-            "cause": e.message,
-        }, 404
+        if request.accept_mimetypes.best == "application/json":
+            return (
+                {
+                    "valid": False,
+                    "message": f"Provided GL String is invalid: {gl_string}",
+                    "cause": e.message,
+                },
+                404,
+                {"Content-Type": "application/json"},
+            )
+        else:
+            return "false", 404, {"Content-Type": "text/plain"}
     except PyArdError as e:
         return {"message": e.message}, 400
 
@@ -63,18 +74,25 @@ def redux_controller(body):
     return {"message": "No input data provided"}, 404
 
 
-def lgx_controller(allele):
+def ard_controller(allele):
     # Perform redux in `lgx` mode
     if allele:
         try:
             redux_string = ard.redux(allele, "lgx")
-            ipd_version = ard.get_db_version()
-            return {
-                "ipd_version": ipd_version,
-                "pyard_version": pyard.__version__,
-                "allele": allele,
-                "ard": redux_string,
-            }, 200
+            if request.accept_mimetypes.best == "application/json":
+                ipd_version = ard.get_db_version()
+                return (
+                    {
+                        "ipd_version": ipd_version,
+                        "pyard_version": pyard.__version__,
+                        "allele": allele,
+                        "ard": redux_string,
+                    },
+                    200,
+                    {"Content-Type": "application/json"},
+                )
+            else:
+                return redux_string, 200, {"Content-Type": "text/plain"}
         except PyArdError as e:
             return {"message": e.message}, 400
     else:
@@ -85,11 +103,18 @@ def xx_expand_controller(xx_code: str):
     try:
         if ard.is_XX(xx_code):
             allele_list = ard.expand_xx(xx_code)
-            return {
-                "xx_code": xx_code,
-                "alleles": allele_list.split("/"),
-                "gl_string": allele_list,
-            }, 200
+            if request.accept_mimetypes.best == "application/json":
+                return (
+                    {
+                        "xx_code": xx_code,
+                        "alleles": allele_list.split("/"),
+                        "gl_string": allele_list,
+                    },
+                    200,
+                    {"Content-Type": "application/json"},
+                )
+            else:
+                return (allele_list, 200, {"Content-Type": "text/plain"})
         else:
             return {"message": f"{xx_code} is not a valid XX Code"}, 404
     except PyArdError as e:
@@ -100,11 +125,18 @@ def mac_expand_controller(allele_code: str):
     try:
         if ard.is_mac(allele_code):
             allele_list = ard.expand_mac(allele_code)
-            return {
-                "mac": allele_code,
-                "alleles": allele_list.split("/"),
-                "gl_string": allele_list,
-            }, 200
+            if request.accept_mimetypes.best == "application/json":
+                return (
+                    {
+                        "mac": allele_code,
+                        "alleles": allele_list.split("/"),
+                        "gl_string": allele_list,
+                    },
+                    200,
+                    {"Content-Type": "application/json"},
+                )
+            else:
+                return (allele_list, 200, {"Content-Type": "text/plain"})
         else:
             return {"message": f"{allele_code} is not a valid MAC"}, 404
     except PyArdError as e:
@@ -115,11 +147,18 @@ def mac_hats_expand_controller(allele_code: str):
     try:
         if ard.is_mac(allele_code):
             allele_list = ard.expand_mac_to_hats_alleles(allele_code)
-            return {
-                "mac": allele_code,
-                "alleles": allele_list.split("/"),
-                "gl_string": allele_list,
-            }, 200
+            if request.accept_mimetypes.best == "application/json":
+                return (
+                    {
+                        "mac": allele_code,
+                        "alleles": allele_list.split("/"),
+                        "gl_string": allele_list,
+                    },
+                    200,
+                    {"Content-Type": "application/json"},
+                )
+            else:
+                return (allele_list, 200, {"Content-Type": "text/plain"})
         else:
             return {"message": f"{allele_code} is not a valid MAC"}, 404
     except PyArdError as e:
@@ -159,10 +198,17 @@ def drbx_blender_controller(body):
 
 def version_controller():
     ipd_version = ard.get_db_version()
-    return {
-        "ipd_version": ipd_version,
-        "pyard_version": pyard.__version__,
-    }, 200
+    if request.accept_mimetypes.best == "application/json":
+        return (
+            {
+                "ipd_version": ipd_version,
+                "pyard_version": pyard.__version__,
+            },
+            200,
+            {"Content-Type": "application/json"},
+        )
+    else:
+        return f"{ipd_version}/{pyard.__version__}", 200, {"Content-Type": "text/plain"}
 
 
 def splits_controller(allele: str):
@@ -189,7 +235,7 @@ def cwd_redux_controller(body):
         if "/" in cwd:
             try:
                 cwd_mac = ard.lookup_mac(cwd)
-            except pyard.exceptions.InvalidMACError as e:
+            except pyard.exceptions.InvalidMACError:
                 cwd_mac = ""
         else:
             cwd_mac = ""

--- a/pyard/__init__.py
+++ b/pyard/__init__.py
@@ -28,7 +28,7 @@ from .constants import DEFAULT_CACHE_SIZE
 from .misc import get_imgt_db_versions as db_versions
 
 __author__ = """NMDP Bioinformatics"""
-__version__ = "2.3.0"
+__version__ = "2.3.1"
 
 
 def init(

--- a/pyard/ard.py
+++ b/pyard/ard.py
@@ -18,6 +18,7 @@ from .exceptions import InvalidMACError, InvalidTypingError
 from .handlers import (
     AlleleHandler,
     GLStringHandler,
+    HATSHandler,
     MACHandler,
     SerologyHandler,
     V2Handler,
@@ -103,6 +104,7 @@ class ARD(object):
         """Initialize all specialized handlers"""
         self.allele_reducer = AlleleHandler(self)
         self.gl_processor = GLStringHandler(self)
+        self.hats_handler = HATSHandler(self)
         self.mac_handler = MACHandler(self)
         self.serology_handler = SerologyHandler(self)
         self.v2_handler = V2Handler(self)
@@ -304,6 +306,12 @@ class ARD(object):
 
     def expand_mac(self, mac_code: str) -> str:
         return self.mac_handler.expand_mac(mac_code)
+
+    def expand_mac_to_hats_alleles(self, mac_code: str) -> str:
+        alleles_from_mac = self.expand_mac(mac_code)
+        if alleles_from_mac:
+            return self.hats_handler.expand_to_hats_alleles(alleles_from_mac)
+        return ""
 
     def lookup_mac(self, allelelist_gl: str) -> str:
         return self.mac_handler.lookup_mac(allelelist_gl)

--- a/pyard/ard.py
+++ b/pyard/ard.py
@@ -308,9 +308,18 @@ class ARD(object):
         return self.mac_handler.expand_mac(mac_code)
 
     def expand_mac_to_hats_alleles(self, mac_code: str) -> str:
-        alleles_from_mac = self.expand_mac(mac_code)
+        if HLA_regex.search(mac_code):
+            hla_prefix = True
+            mac_code_no_prefix = mac_code.split("-")[1]
+            alleles_from_mac = self.expand_mac(mac_code_no_prefix)
+        else:
+            hla_prefix = False
+            alleles_from_mac = self.expand_mac(mac_code)
         if alleles_from_mac:
-            return self.hats_handler.expand_to_hats_alleles(alleles_from_mac)
+            alleles = self.hats_handler.expand_to_hats_alleles(alleles_from_mac)
+            if hla_prefix:
+                return "/".join([f"HLA-{a}" for a in alleles.split("/")])
+            return alleles
         return ""
 
     def lookup_mac(self, allelelist_gl: str) -> str:

--- a/pyard/data_repository.py
+++ b/pyard/data_repository.py
@@ -386,12 +386,10 @@ def _generate_antigen_specifities(db_connection, serology_mapping_df):
     """
     hats_df = serology_mapping_df.where_not_null("HATS")[["Locus*Allele", "HATS"]]
     hats_df.rename({"Locus*Allele": "Allele"})
-    hats_df["1F"] = hats_df["Allele"].apply(get_1field_allele)
     hats_df["2F"] = hats_df["Allele"].apply(get_2field_allele)
     hats_df["3F"] = hats_df["Allele"].apply(get_3field_allele)
     hats_final = (
         hats_df[["Allele", "HATS"]]
-        .union(hats_df[["1F", "HATS"]].rename({"1F": "Allele"}))
         .union(hats_df[["2F", "HATS"]].rename({"2F": "Allele"}))
         .union(hats_df[["3F", "HATS"]].rename({"3F": "Allele"}))
     )

--- a/pyard/db.py
+++ b/pyard/db.py
@@ -445,6 +445,30 @@ def find_hats(connection: sqlite3.Connection, allele: str) -> str:
     return None
 
 
+def find_common_hats_alleles(
+    connection: sqlite3.Connection, alleles: List[str]
+) -> List[str]:
+    """
+    Find all alleles that share the same HATS assignments as the given alleles.
+
+    :param connection: db connection of type sqlite.Connection
+    :param alleles: list of alleles to look up
+    :return: list of all alleles sharing the same HATS assignments
+    """
+    placeholders = ",".join("?" * len(alleles))
+    query = f"""
+        SELECT allele FROM antigen_specifities
+        WHERE hats IN (
+            SELECT DISTINCT hats FROM antigen_specifities
+            WHERE allele IN ({placeholders})
+        )
+    """
+    cursor = connection.execute(query, alleles)
+    results = [row[0] for row in cursor.fetchall()]
+    cursor.close()
+    return results
+
+
 def get_user_version(connection: sqlite3.Connection) -> int:
     """
     Retrieve user_version from db

--- a/pyard/handlers/__init__.py
+++ b/pyard/handlers/__init__.py
@@ -2,6 +2,7 @@
 
 from .allele_handler import AlleleHandler
 from .gl_string_processor import GLStringHandler
+from .hats_handler import HATSHandler
 from .mac_handler import MACHandler
 from .serology_handler import SerologyHandler
 from .shortnull_handler import ShortNullHandler
@@ -11,6 +12,7 @@ from .xx_handler import XXHandler
 __all__ = [
     "AlleleHandler",
     "GLStringHandler",
+    "HATSHandler",
     "MACHandler",
     "SerologyHandler",
     "V2Handler",

--- a/pyard/handlers/hats_handler.py
+++ b/pyard/handlers/hats_handler.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+import functools
+from typing import TYPE_CHECKING
+
+
+from .. import db
+from ..misc import is_2_field_allele
+
+if TYPE_CHECKING:
+    from ..ard import ARD
+
+
+class HATSHandler:
+    def __init__(self, ard_instance: "ARD"):
+        self.ard = ard_instance
+
+    def expand_to_hats_alleles(self, alleles_gl: str) -> str:
+        alleles = alleles_gl.split("/")
+        hats_alleles = db.find_common_hats_alleles(self.ard.db_connection, alleles)
+        # MAC expanded alleles should only be 2 field level alleles
+        hats_alleles_2fields = filter(is_2_field_allele, hats_alleles)
+        return "/".join(
+            sorted(
+                hats_alleles_2fields,
+                key=functools.cmp_to_key(self.ard.smart_sort_comparator),
+            )
+        )

--- a/pyard/handlers/hats_handler.py
+++ b/pyard/handlers/hats_handler.py
@@ -17,12 +17,16 @@ class HATSHandler:
 
     def expand_to_hats_alleles(self, alleles_gl: str) -> str:
         alleles = alleles_gl.split("/")
+        locus = alleles[0].split("*")[0]
         hats_alleles = db.find_common_hats_alleles(self.ard.db_connection, alleles)
         # MAC expanded alleles should only be 2 field level alleles
         hats_alleles_2fields = filter(is_2_field_allele, hats_alleles)
+        hats_alleles_same_locus = filter(
+            lambda a: a.split("*")[0] == locus, hats_alleles_2fields
+        )
         return "/".join(
             sorted(
-                hats_alleles_2fields,
+                hats_alleles_same_locus,
                 key=functools.cmp_to_key(self.ard.smart_sort_comparator),
             )
         )

--- a/scripts/pyard
+++ b/scripts/pyard
@@ -158,6 +158,11 @@ if __name__ == "__main__":
         "--expand", dest="expand", help="Expand MAC or XX code to Allele List"
     )
     parser.add_argument(
+        "--expand-mac-hats",
+        dest="expand_mac_hats",
+        help="Expand MAC to HATS Allele List",
+    )
+    parser.add_argument(
         "--similar",
         dest="similar_allele",
         help="Find Similar Alleles with given prefix",
@@ -193,6 +198,11 @@ if __name__ == "__main__":
     # Handle --splits option
     if args.splits:
         find_broad_splits(ard)
+
+    # Handle --expand-mac-hats option
+    if args.expand_mac_hats:
+        print(ard.expand_mac_to_hats_alleles(args.expand_mac_hats))
+        sys.exit(0)
 
     # Handle --expand-mac option
     if args.expand_mac:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.3.0
+current_version = 2.3.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ script_extras = {"script": ["pandas>=2.0"]}
 
 setup(
     name="py-ard",
-    version="2.3.0",
+    version="2.3.1",
     description="ARD reduction for HLA with Python",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Add `ard.expand_mac_to_hats_alleles(mac_code)`
- Add `HATSHandler` with `expand_to_hats_alleles` that maps a MAC-expanded allele list to all alleles sharing the same HATS assignments
- Add `db.find_common_hats_alleles` using a subquery to fetch all alleles in `antigen_specifities` whose hats value matches any of the input alleles

Webservice updates:
- Add `/mac-hats/{allele_code}` web-service end point.
- Support `text/plain` accept for `/version`, `/ard`, `/mac`, `/mac-hats/` and `/xx` endpoints
- Allow `1F` and `hats` redux modes

Update `Dockerfile-local` to match the main `Dockerfile`
Bump version: 2.3.0 → 2.3.1