### PR TITLE
Supports `.pyardrc` config file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL MAINTAINER="Pradeep Bashyal"
 
 WORKDIR /app
 
-ARG PY_ARD_VERSION=2.3.1
+ARG PY_ARD_VERSION=2.4.0
 
 COPY requirements.txt /app
 RUN pip install --no-cache-dir --upgrade pip && \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT_NAME := $(shell basename `pwd`)
 PACKAGE_NAME := pyard
-PYARD_VERSION := 2.3.1
+PYARD_VERSION := 2.4.0
 
 .PHONY: help clean clean-test clean-pyc clean-build docs behave lint pytest test coverage docs servedocs release dist docker-build docker install venv activate
 .DEFAULT_GOAL := help

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ another based on alleles published quarterly by [IPD/IMGT-HLA](https://github.co
 2. [Using `py-ard`](#using-py-ard)
     * [Using `py-ard` from Python](#using-py-ard-from-python-code)
     * [Using `py-ard` from R](#using-py-ard-from-r-code)
+    * [`.pyardrc` Configuration File](#pyardrc-configuration-file)
     * [Perform Reduction](#reduce-typings)
     * [DRBX blending](#perform-drb1-blending-with-drb3-drb4-and-drb5)
     * [Expand/Lookup MAC](#mac-codes)
@@ -189,6 +190,56 @@ config = {
 }
 
 ard = pyard.init('3510', config=config)
+```
+
+### `.pyardrc` Configuration File
+
+`py-ard` looks for a `.pyardrc` file in the current directory first, then in the home directory (`~/`).
+When found, it is used as the default configuration for `pyard.init()`,
+so you can call `pyard.init()` with no arguments and have your preferred settings applied automatically.
+
+The file uses [TOML](https://toml.io) format.
+Copy [`extras/sample.pyardrc`](extras/sample.pyardrc) as a starting template:
+
+```shell
+cp extras/sample.pyardrc ~/.pyardrc
+```
+
+The `[pyard]` table maps to the `pyard.init()` parameters:
+
+```toml
+[pyard]
+imgt_version = "3640"
+data_dir = "~/.py-ard/"
+load_mac = true
+cache_size = 1000
+```
+
+The `[pyard.config]` table maps to the `ARDConfig` reduction settings:
+
+```toml
+[pyard.config]
+reduce_serology = true
+reduce_v2 = true
+reduce_3field = true
+reduce_P = true
+reduce_XX = true
+reduce_MAC = true
+reduce_shortnull = true
+ping = true
+verbose_log = false
+ARS_as_lg = false
+strict = true
+ignore_allele_with_suffixes = []
+```
+
+Any argument passed explicitly to `pyard.init()` takes precedence over the `.pyardrc` values:
+
+You can set the environment variable `PYARD_RC` to `no` to skip reading the `.pyardrc` config.
+
+```shell
+export PYARD_RC=no
+pyard -g "A*02:01" -r hats
 ```
 
 ### Reduce Typings

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -7,7 +7,7 @@ info:
     based on IPD-IMGT/HLA allele data.
 
     See [py-ard.org](https://py-ard.org) for full documentation.
-  version: "2.3.1"
+  version: "2.4.0"
   license:
     name: LGPL-3
     url: https://www.gnu.org/licenses/lgpl-3.0.html

--- a/extras/sample.pyardrc
+++ b/extras/sample.pyardrc
@@ -1,0 +1,19 @@
+[pyard]
+imgt_version = 3640
+data_dir = "~/.py-ard/"
+load_mac = true
+cache_size = 1000
+
+[pyard.config]
+reduce_serology = true
+reduce_v2 = true
+reduce_3field = true
+reduce_P = true
+reduce_XX = true
+reduce_MAC = true
+reduce_shortnull = true
+ping = true
+verbose_log = false
+ARS_as_lg = false
+strict = true
+ignore_allele_with_suffixes = []

--- a/pyard/__init__.py
+++ b/pyard/__init__.py
@@ -20,6 +20,7 @@
 #    > http://www.fsf.org/licensing/licenses/lgpl.html
 #    > http://www.opensource.org/licenses/lgpl-license.php
 #
+import os
 
 # exports for `pyard`
 from .blender import blender as dr_blender
@@ -32,19 +33,32 @@ __version__ = "2.3.1"
 
 
 def init(
-    imgt_version: str = "Latest",
+    imgt_version: str = None,
     data_dir: str = None,
-    load_mac: bool = True,
-    cache_size: int = DEFAULT_CACHE_SIZE,
+    load_mac: bool = None,
+    cache_size: int = None,
     config: dict = None,
 ):
     from .ard import ARD
+    from .rc import load_rc
 
-    ard = ARD(
-        imgt_version=imgt_version,
-        data_dir=data_dir,
-        load_mac=load_mac,
-        max_cache_size=cache_size,
-        config=config,
-    )
-    return ard
+    if os.getenv("PYARD_RC") != "no":
+        rc = load_rc()
+    else:
+        rc = {}
+    resolved = {
+        "imgt_version": (
+            imgt_version
+            if imgt_version is not None
+            else rc.get("imgt_version", "Latest")
+        ),
+        "data_dir": data_dir if data_dir is not None else rc.get("data_dir"),
+        "load_mac": load_mac if load_mac is not None else rc.get("load_mac", True),
+        "max_cache_size": (
+            cache_size
+            if cache_size is not None
+            else rc.get("cache_size", DEFAULT_CACHE_SIZE)
+        ),
+        "config": config if config is not None else rc.get("config"),
+    }
+    return ARD(**resolved)

--- a/pyard/__init__.py
+++ b/pyard/__init__.py
@@ -29,7 +29,7 @@ from .constants import DEFAULT_CACHE_SIZE
 from .misc import get_imgt_db_versions as db_versions
 
 __author__ = """NMDP Bioinformatics"""
-__version__ = "2.3.1"
+__version__ = "2.4.0"
 
 
 def init(

--- a/pyard/db.py
+++ b/pyard/db.py
@@ -21,7 +21,7 @@
 #    > http://www.opensource.org/licenses/lgpl-license.php
 #
 import os
-import pathlib
+from pathlib import Path
 import sqlite3
 import sys
 from typing import Tuple, Dict, Set, List
@@ -44,11 +44,12 @@ def create_db_connection(data_dir, imgt_version, ro=False):
     if data_dir is None:
         data_dir = get_default_db_directory()
 
-    db_filename = f"{data_dir}/pyard-{imgt_version}.sqlite3"
+    db_path_dir = Path(data_dir).expanduser()
+    db_filename = db_path_dir / f"pyard-{imgt_version}.sqlite3"
 
     if ro:
         # If in read-only mode, make sure the db file exists
-        if not pathlib.Path(db_filename).exists():
+        if not db_filename.exists():
             raise RuntimeError(f"Reference Database {db_filename}  not available.")
         # Open the database in read-only mode
         file_uri = f"file:{db_filename}?mode=ro"
@@ -58,7 +59,7 @@ def create_db_connection(data_dir, imgt_version, ro=False):
     # Check the imgt_version is a valid IPD/IMGT-HLA DB Version
     # by querying the IPD/IMGT-HLA site
     if imgt_version != "Latest":
-        if not pathlib.Path(db_filename).exists():
+        if not db_filename.exists():
             all_imgt_versions = get_imgt_db_versions()
             if str(imgt_version) not in all_imgt_versions:
                 raise ValueError(
@@ -66,11 +67,11 @@ def create_db_connection(data_dir, imgt_version, ro=False):
                 )
 
     # Create the data directory if it doesn't exist
-    if not pathlib.Path(data_dir).exists():
-        pathlib.Path(data_dir).mkdir(parents=True, exist_ok=True)
+    if not db_path_dir.exists():
+        db_path_dir.mkdir(parents=True, exist_ok=True)
 
     # Check for permission to read/write
-    if pathlib.Path(db_filename).exists():
+    if db_filename.exists():
         # Check file is readable
         if not os.access(db_filename, os.R_OK):
             print(
@@ -80,7 +81,7 @@ def create_db_connection(data_dir, imgt_version, ro=False):
             sys.exit(1)
     else:
         # Check directory is writeable
-        if os.access(data_dir, os.W_OK):
+        if os.access(db_path_dir, os.W_OK):
             print(f"Creating {db_filename} as cache.")
         else:
             print(

--- a/pyard/rc.py
+++ b/pyard/rc.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+
+from pathlib import Path
+
+RC_FILENAME = ".pyardrc"
+
+_RC_SEARCH_PATHS = [
+    Path.cwd(),
+    Path.home(),
+]
+
+
+def _find_rc_file() -> Path | None:
+    for directory in _RC_SEARCH_PATHS:
+        rc = directory / RC_FILENAME
+        if rc.exists():
+            return rc
+    return None
+
+
+def load_rc() -> dict:
+    """Load .pyardrc and return kwargs suitable for pyard.init()"""
+    rc_file = _find_rc_file()
+    if rc_file is None:
+        return {}
+
+    try:
+        import tomllib
+
+        with open(rc_file, "rb") as f:
+            data = tomllib.load(f)
+    except ImportError:
+        import toml  # Python < 3.11
+
+        data = toml.load(rc_file)
+
+    pyard_section = data.get("pyard", {})
+    config_section = pyard_section.pop("config", None)
+
+    kwargs = dict(pyard_section)
+    if config_section is not None:
+        # Convert list to tuple for 'ignore_allele_with_suffixes'
+        if "ignore_allele_with_suffixes" in config_section:
+            config_section["ignore_allele_with_suffixes"] = tuple(
+                config_section["ignore_allele_with_suffixes"]
+            )
+        kwargs["config"] = config_section
+
+    print(f"-- Loading config from {rc_file}")
+    return kwargs

--- a/scripts/pyard-import
+++ b/scripts/pyard-import
@@ -47,7 +47,7 @@ def get_v2_v3_mapping(v2_v3_mapping):
 
         path = pathlib.Path(v2_v3_mapping)
         if not path.exists() or not path.is_file():
-            raise RuntimeError(f"{data_dir} is not a valid file")
+            raise RuntimeError(f"{path} is not a valid file")
         df = pd.read_csv(path, names=["v2", "v3"])
         return df.set_index("v2")["v3"].to_dict()
     return None

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.3.1
+current_version = 2.4.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ script_extras = {"script": ["pandas>=2.0"]}
 
 setup(
     name="py-ard",
-    version="2.3.1",
+    version="2.4.0",
     description="ARD reduction for HLA with Python",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
`.pyardrc` file to configure py-ard settings 

- Looks for `.pyardrc` file in `$CWD` and `~` order
- Sample `.pyardrc` file in extras
- set `PYARD_RC=no` to turn off using `.pyardrc`
- Add documentation on use

Fix path issues
- when the path has `~` for home directory.
- typo in `pyard-import` 

Bump version: 2.3.1 → 2.4.0

Fixes #379 
Fixes #394